### PR TITLE
名前を付ける機能

### DIFF
--- a/pages/browser/[...pathes]/components/AddArea.tsx
+++ b/pages/browser/[...pathes]/components/AddArea.tsx
@@ -111,11 +111,11 @@ const ShowAddArea = styled.span`
   }
 `
 
-export const AddArea = (props: { AddFile: () => void; AddFolder: () => void }) => {
+export const AddArea = (props: { addFile: () => void; addFolder: () => void }) => {
   return (
     <ShowAddArea>
-      <StyledFileAdd onClick={props.AddFile} />
-      <StyledFolderAdd onClick={props.AddFolder} />
+      <StyledFileAdd onClick={props.addFile} />
+      <StyledFolderAdd onClick={props.addFolder} />
     </ShowAddArea>
   )
 }

--- a/pages/browser/[...pathes]/components/Explorer/CellName.tsx
+++ b/pages/browser/[...pathes]/components/Explorer/CellName.tsx
@@ -83,7 +83,7 @@ export const CellName = (props: {
             <>
               <Arrow opened={props.opened} />
               <Spacer axis="x" size={18} />
-              <AddArea AddFile={onClick} AddFolder={onClick} />
+              <AddArea addFile={onClick} addFolder={onClick} />
             </>
           )}
           {props.name}


### PR DESCRIPTION
ファイル・フォルダ追加ボタンをクリック時に名前を付ける欄を表示させました。
名前を付ける欄は入力がなければ入力欄が閉じる仕様になっています。
![動作確認](https://user-images.githubusercontent.com/88891567/136394860-8fd51ee2-8d0e-4c02-b87d-4d64b6b3fc64.gif)