### PR TITLE
ファイルツリー表示部分で横にスクロールできてしまう箇所修正

### DIFF
--- a/pages/browser/[...pathes]/components/AddArea.tsx
+++ b/pages/browser/[...pathes]/components/AddArea.tsx
@@ -9,7 +9,6 @@ const StyledFileAdd = styled.i`
   margin-right: 10px;
   overflow: hidden;
   color: #333;
-  visibility: hidden;
   background: linear-gradient(to bottom, #333 5px, transparent 0) no-repeat 1px 7px/6px 2px;
   border: 2px solid transparent;
   border-top: 0;
@@ -57,7 +56,6 @@ const StyledFolderAdd = styled.i`
   margin: 1.5px 0 1px 0;
   margin-right: 10px;
   color: #333;
-  visibility: hidden;
   background: linear-gradient(to left, #333 10px, transparent 0) no-repeat 7px 2px/2px 6px;
   border: 2px solid;
   border-radius: 3px;
@@ -97,25 +95,11 @@ const StyledFolderAdd = styled.i`
   }
 `
 
-const ShowAddArea = styled.div`
-  position: absolute;
-  width: 100%;
-  &:hover {
-    width: 120%;
-    ${StyledFileAdd} {
-      visibility: visible;
-    }
-    ${StyledFolderAdd} {
-      visibility: visible;
-    }
-  }
-`
-
 export const AddArea = (props: { addFile: () => void; addFolder: () => void }) => {
   return (
-    <ShowAddArea>
+    <>
       <StyledFileAdd onClick={props.addFile} />
       <StyledFolderAdd onClick={props.addFolder} />
-    </ShowAddArea>
+    </>
   )
 }

--- a/pages/browser/[...pathes]/components/AddArea.tsx
+++ b/pages/browser/[...pathes]/components/AddArea.tsx
@@ -4,12 +4,12 @@ const StyledFileAdd = styled.i`
   box-sizing: border-box;
   float: right;
   width: 12px;
-  height: 14px;
+  height: 13px;
   margin: 1px 0 1px 0;
   margin-right: 10px;
   overflow: hidden;
   color: #333;
-  background: linear-gradient(to bottom, #333 5px, transparent 0) no-repeat 1px 7px/6px 2px;
+  background: linear-gradient(to bottom, #333 5px, transparent 0) no-repeat 1px 6px/6px 2px;
   border: 2px solid transparent;
   border-top: 0;
   border-right: 0;
@@ -29,7 +29,7 @@ const StyledFileAdd = styled.i`
     content: '';
   }
   &::before {
-    top: 5px;
+    top: 4px;
     left: 3px;
     width: 2px;
     background: #333;
@@ -52,7 +52,7 @@ const StyledFolderAdd = styled.i`
   box-sizing: border-box;
   float: right;
   width: 20px;
-  height: 14px;
+  height: 13px;
   margin: 1.5px 0 1px 0;
   margin-right: 10px;
   color: #333;

--- a/pages/browser/[...pathes]/components/AddArea.tsx
+++ b/pages/browser/[...pathes]/components/AddArea.tsx
@@ -6,7 +6,7 @@ const StyledFileAdd = styled.i`
   width: 12px;
   height: 14px;
   margin: 1px 0 1px 0;
-  margin-right: 20px;
+  margin-right: 10px;
   overflow: hidden;
   color: #333;
   visibility: hidden;
@@ -99,8 +99,9 @@ const StyledFolderAdd = styled.i`
 
 const ShowAddArea = styled.span`
   position: absolute;
+  display: flex;
+  justify-content: flex-end;
   width: 100%;
-  height: 100%;
   &:hover {
     ${StyledFileAdd} {
       visibility: visible;

--- a/pages/browser/[...pathes]/components/AddArea.tsx
+++ b/pages/browser/[...pathes]/components/AddArea.tsx
@@ -97,10 +97,11 @@ const StyledFolderAdd = styled.i`
   }
 `
 
-const ShowAddArea = styled.span`
+const ShowAddArea = styled.div`
   position: absolute;
   width: 100%;
   &:hover {
+    width: 120%;
     ${StyledFileAdd} {
       visibility: visible;
     }

--- a/pages/browser/[...pathes]/components/AddArea.tsx
+++ b/pages/browser/[...pathes]/components/AddArea.tsx
@@ -99,8 +99,6 @@ const StyledFolderAdd = styled.i`
 
 const ShowAddArea = styled.span`
   position: absolute;
-  display: flex;
-  justify-content: flex-end;
   width: 100%;
   &:hover {
     ${StyledFileAdd} {

--- a/pages/browser/[...pathes]/components/Explorer/CellName.tsx
+++ b/pages/browser/[...pathes]/components/Explorer/CellName.tsx
@@ -20,9 +20,14 @@ const Container = styled.a<{ depth: number; selected: boolean; bold?: boolean }>
   ${SelectableStyle};
 `
 
-const Label = styled.div`
+const LabelArea = styled.div`
   position: relative;
   display: flex;
+`
+const Label = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `
 
 const Arrow = styled.div<{ opened?: boolean }>`
@@ -131,7 +136,7 @@ export const CellName = (props: {
     <Link href={href}>
       {props.name && (
         <Container depth={pathChunks.length - 1} selected={props.selected} bold={props.bold}>
-          <Label>
+          <LabelArea>
             {props.isWork ? (
               <>
                 <ExtIcon name={props.name} />
@@ -144,8 +149,8 @@ export const CellName = (props: {
                 <AddArea addFile={AddNewFile} addFolder={AddNewFolder} />
               </>
             )}
-            {props.name}
-          </Label>
+            <Label>{props.name}</Label>
+          </LabelArea>
           {isClickNewAdd && !isFocusing && (
             <NewFileFolderArea depth={pathChunks.length - 1}>
               <form onSubmit={sendNewName}>

--- a/pages/browser/[...pathes]/components/Explorer/CellName.tsx
+++ b/pages/browser/[...pathes]/components/Explorer/CellName.tsx
@@ -20,22 +20,26 @@ const Container = styled.a<{ depth: number; selected: boolean; bold?: boolean }>
   ${SelectableStyle};
 `
 
+const AddAreaParent = styled.div`
+  display: none;
+`
+
 const LabelArea = styled.div`
   position: relative;
   display: flex;
-  height: 100%;
-  &:hover {
-    width: 80%;
+  :hover {
+    ${AddAreaParent} {
+      display: inline-block;
+    }
   }
 `
+
 const Label = styled.div`
   flex: 1;
+  padding: 0.5px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-
-  /* &:hover {
-  } */
 `
 
 const Arrow = styled.div<{ opened?: boolean }>`
@@ -149,15 +153,18 @@ export const CellName = (props: {
               <>
                 <ExtIcon name={props.name} />
                 <Spacer axis="x" size={6} />
+                <Label>{props.name}</Label>
               </>
             ) : (
               <>
                 <Arrow opened={props.opened} />
                 <Spacer axis="x" size={18} />
-                <AddArea addFile={AddNewFile} addFolder={AddNewFolder} />
+                <Label>{props.name}</Label>
+                <AddAreaParent>
+                  <AddArea addFile={AddNewFile} addFolder={AddNewFolder} />
+                </AddAreaParent>
               </>
             )}
-            <Label>{props.name}</Label>
           </LabelArea>
           {isClickNewAdd && !isFocusing && (
             <NewFileFolderArea depth={pathChunks.length - 1}>

--- a/pages/browser/[...pathes]/components/Explorer/CellName.tsx
+++ b/pages/browser/[...pathes]/components/Explorer/CellName.tsx
@@ -28,10 +28,8 @@ const AddAreaParent = styled.div`
 const LabelArea = styled.div`
   position: relative;
   display: flex;
-  :hover {
-    ${AddAreaParent} {
-      display: block;
-    }
+  :hover ${AddAreaParent} {
+    display: block;
   }
 `
 

--- a/pages/browser/[...pathes]/components/Explorer/CellName.tsx
+++ b/pages/browser/[...pathes]/components/Explorer/CellName.tsx
@@ -23,11 +23,19 @@ const Container = styled.a<{ depth: number; selected: boolean; bold?: boolean }>
 const LabelArea = styled.div`
   position: relative;
   display: flex;
+  height: 100%;
+  &:hover {
+    width: 80%;
+  }
 `
 const Label = styled.div`
+  flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  /* &:hover {
+  } */
 `
 
 const Arrow = styled.div<{ opened?: boolean }>`

--- a/pages/browser/[...pathes]/components/Explorer/CellName.tsx
+++ b/pages/browser/[...pathes]/components/Explorer/CellName.tsx
@@ -22,6 +22,7 @@ const Container = styled.a<{ depth: number; selected: boolean; bold?: boolean }>
 
 const AddAreaParent = styled.div`
   display: none;
+  order: 1;
 `
 
 const LabelArea = styled.div`
@@ -29,14 +30,13 @@ const LabelArea = styled.div`
   display: flex;
   :hover {
     ${AddAreaParent} {
-      display: inline-block;
+      display: block;
     }
   }
 `
 
 const Label = styled.div`
   flex: 1;
-  padding: 0.5px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -153,18 +153,17 @@ export const CellName = (props: {
               <>
                 <ExtIcon name={props.name} />
                 <Spacer axis="x" size={6} />
-                <Label>{props.name}</Label>
               </>
             ) : (
               <>
                 <Arrow opened={props.opened} />
                 <Spacer axis="x" size={18} />
-                <Label>{props.name}</Label>
                 <AddAreaParent>
                   <AddArea addFile={AddNewFile} addFolder={AddNewFolder} />
                 </AddAreaParent>
               </>
             )}
+            <Label>{props.name}</Label>
           </LabelArea>
           {isClickNewAdd && !isFocusing && (
             <NewFileFolderArea depth={pathChunks.length - 1}>

--- a/pages/browser/[...pathes]/components/Explorer/CellName.tsx
+++ b/pages/browser/[...pathes]/components/Explorer/CellName.tsx
@@ -22,6 +22,7 @@ const Container = styled.a<{ depth: number; selected: boolean; bold?: boolean }>
 
 const Label = styled.div`
   position: relative;
+  display: flex;
 `
 
 const Arrow = styled.div<{ opened?: boolean }>`


### PR DESCRIPTION
### 対応内容

- ファイルツリー表示部分で横へスクロールできてしまっていた箇所を修正
- ファイル・フォルダ名がオーバーフローしてしまったときに三点リーダーを表示
- ファイル・フォルダ名がオーバーフロー時でもファイル・フォルダ追加アイコンを押せるように改修

### 修正後の動作動作
![動作確認 issue60](https://user-images.githubusercontent.com/88891567/140027725-552f150c-ffbb-4d20-a573-38d4d31df8fc.gif)

