### PR TITLE
続けてフォルダが追加できなかった処理を修正

### DIFF
--- a/pages/browser/[...pathes]/components/Explorer/CellName.tsx
+++ b/pages/browser/[...pathes]/components/Explorer/CellName.tsx
@@ -100,24 +100,26 @@ export const CellName = (props: {
     openInputField()
     setIsClickNewAddFolder(true)
   }
-  const submitNew = async (path: string, name: string, ext?: string) => {
-    const { projectId, deskName } = getProjectInfo(pathChunks)
-    const desks = await api.browser.projects._projectId(projectId).desks.$get()
-    const desk = desks.desks.find((d) => d.name === deskName)
-    if (!desk) return
-    await api.browser.projects
-      ._projectId(projectId)
-      .desks._deskId(desk.id)
-      .post({ body: { path, name, ext } })
-      .catch(onErr)
-    const deskRes = await api.browser.projects._projectId(projectId).desks.$get()
-
-    updateApiWholeData(
-      'desksList',
-      apiWholeData.desksList.map((d) => (d.projectId === deskRes.projectId ? deskRes : d))
-    )
-    setIsClickNewAdd(false)
-  }
+  const submitNew = useCallback(
+    async (path: string, name: string, ext?: string) => {
+      const { projectId, deskName } = getProjectInfo(pathChunks)
+      const desks = await api.browser.projects._projectId(projectId).desks.$get()
+      const desk = desks.desks.find((d) => d.name === deskName)
+      if (!desk) return
+      await api.browser.projects
+        ._projectId(projectId)
+        .desks._deskId(desk.id)
+        .post({ body: { path, name, ext } })
+        .catch(onErr)
+      const deskRes = await api.browser.projects._projectId(projectId).desks.$get()
+      updateApiWholeData(
+        'desksList',
+        apiWholeData.desksList.map((d) => (d.projectId === deskRes.projectId ? deskRes : d))
+      )
+      setIsClickNewAdd(false)
+    },
+    [apiWholeData.desksList]
+  )
   const createNew = () => {
     const pathArray = pathChunks.filter((d) => pathChunks.indexOf(d) > 1)
     if (isClickNewAddFile) {


### PR DESCRIPTION
      updateApiWholeData(
        'desksList',
        apiWholeData.desksList.map((d) => (d.projectId === deskRes.projectId ? deskRes : d))
      )
調査を行ったところ上記処理で追加するworkが入る前のデータが返ってきていることが分かり、
useCallbackを使うことにより処理が正しくいくようになった。