### PR TITLE
chore: eslint 修正と .prisma/client の禁止

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,9 +62,10 @@ module.exports = {
             patterns: [
               {
                 group: [
+                  '.prisma/*',
                   ...pkgs
                     .filter((pkg2) => pkg2 !== pkg && pkg2 !== 'api' && pkg2 !== 'def')
-                    .map((pkg2) => `!@violet/${pkg2}`),
+                    .map((pkg2) => `@violet/${pkg2}`),
                   ...(pkg === 'api' ? [] : ['@violet/api/src/*']),
                 ],
                 message: `only allowed to import modules under @violet/${pkg}, @violet/def, @violet/api/api and @violet/api/types`,


### PR DESCRIPTION
関連: https://github.com/violet-ts/violet/pull/89

上記のあとに merge できるようになります。

no-restricted-import の設定少しミスっていたのでその修正も込み。 ( `api` 以外の 、 `@violet/scripts/...` などへの禁止ができていなかった)