### PR TITLE
Lambda convert to image のデプロイのための作業、ログの強化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,4 @@ TZ=Asia/Tokyo
 MINIO_ROOT_USER=minio
 MINIO_ROOT_PASSWORD=password
 S3_ENDPOINT=http://localhost:9000
+PRETTY_LOGGING=1

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@ API_PORT=8080
 API_BASE_PATH=/api
 API_ORIGIN=http://localhost:8080
 S3_REGION=ap-northeast-1
-S3_BUCKET=violet-app
+S3_BUCKET_ORIGINAL=violet-app-original
+S3_BUCKET_CONVERTED=violet-app-converted
 
 # local
 MYSQL_DATABASE=dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,11 +57,16 @@ services:
     env_file:
       - ./.env
     entrypoint: []
-    command: >
-      sh -c "mc alias set minio http://minio:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD;
-      mc admin config set minio notify_webhook:1 queue_limit='0' endpoint='http://lambda:8080/2015-03-31/functions/function/invocations' queue_dir='';
-      mc admin service restart minio;
-      mc event add minio/$$S3_BUCKET arn:minio:sqs::1:webhook --event put"
+    command: |
+      sh -c "
+        set -euxo pipefail
+        mc alias set minio http://minio:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD
+        mc mb minio/$$S3_BUCKET_ORIGINAL || true
+        mc mb minio/$$S3_BUCKET_CONVERTED || true
+        mc admin config set minio notify_webhook:1 queue_limit='0' endpoint='http://lambda:8080/2015-03-31/functions/function/invocations' queue_dir=''
+        mc admin service restart minio
+        mc event add minio/$$S3_BUCKET_ORIGINAL arn:minio:sqs::1:webhook --event put || true
+      "
 
 volumes:
   mysql_data:

--- a/pkg/api/package.json
+++ b/pkg/api/package.json
@@ -31,9 +31,9 @@
     "seed": "pnpm run prisma:seed:dev"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.29.0",
-    "@aws-sdk/credential-providers": "^3.38.0",
-    "@aws-sdk/s3-request-presigner": "^3.30.0",
+    "@aws-sdk/client-s3": "^3.41.0",
+    "@aws-sdk/credential-providers": "^3.41.0",
+    "@aws-sdk/s3-request-presigner": "^3.41.0",
     "@prisma/client": "^3.2.1",
     "arg": "^5.0.1",
     "aspida": "^1.7.1",

--- a/pkg/api/src/entries/index.ts
+++ b/pkg/api/src/entries/index.ts
@@ -1,12 +1,28 @@
 import server from '@violet/api/$server'
+import { getCredentials } from '@violet/api/src/service/aws-credential'
 import envValues from '@violet/api/src/utils/envValues'
+import type { Logger } from '@violet/lib/logger'
+import { createLogger } from '@violet/lib/logger'
+import type { FastifyLoggerInstance } from 'fastify'
 import Fastify from 'fastify'
 import cors from 'fastify-cors'
 import helmet from 'fastify-helmet'
 
 const { API_BASE_PATH, API_PORT } = envValues
+const credentials = getCredentials()
 
-const fastify = Fastify()
+const logger = createLogger({ env: envValues, service: '', credentials })
+const convertTofastifyLogger = (logger: Logger): FastifyLoggerInstance => ({
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: logger.warn.bind(logger),
+  error: logger.error.bind(logger),
+  fatal: logger.error.bind(logger),
+  child: (bindings) => convertTofastifyLogger(logger.child(bindings)),
+})
+
+const fastify = Fastify({ logger: convertTofastifyLogger(logger) })
 
 const startServer = async () => {
   server(fastify, { basePath: API_BASE_PATH })

--- a/pkg/api/src/entries/index.ts
+++ b/pkg/api/src/entries/index.ts
@@ -1,5 +1,4 @@
 import server from '@violet/api/$server'
-import { createBucketIfNotExists } from '@violet/api/src/service/s3'
 import envValues from '@violet/api/src/utils/envValues'
 import Fastify from 'fastify'
 import cors from 'fastify-cors'
@@ -10,7 +9,6 @@ const { API_BASE_PATH, API_PORT } = envValues
 const fastify = Fastify()
 
 const startServer = async () => {
-  await createBucketIfNotExists()
   server(fastify, { basePath: API_BASE_PATH })
   fastify.listen(API_PORT, '::')
   console.log(`API started on :: port ${API_PORT}`)

--- a/pkg/api/src/utils/s3.ts
+++ b/pkg/api/src/utils/s3.ts
@@ -1,4 +1,5 @@
 import type { DeskId, ProjectId, RevisionId, S3SaveWorksPath } from '@violet/api/types'
+import { worksOriginalKeyPrefix } from '@violet/def/constants/s3'
 
 export const createS3SaveWorksPath = (props: {
   projectId: ProjectId
@@ -6,4 +7,4 @@ export const createS3SaveWorksPath = (props: {
   revisionId: RevisionId
   filename: string
 }) =>
-  `${props.projectId}/${props.deskId}/revisions/${props.revisionId}/original/${props.filename}` as S3SaveWorksPath
+  `${worksOriginalKeyPrefix}/${props.projectId}/${props.deskId}/revisions/${props.revisionId}/${props.filename}` as S3SaveWorksPath

--- a/pkg/def/constants/s3.ts
+++ b/pkg/def/constants/s3.ts
@@ -1,0 +1,2 @@
+export const worksOriginalKeyPrefix = 'works/original'
+export const worksConvertedKeyPrefix = 'works/converted'

--- a/pkg/def/envValues.ts
+++ b/pkg/def/envValues.ts
@@ -4,9 +4,10 @@ export interface VioletEnv {
   API_PORT: number
   AWS_ACCESS_KEY_ID: string
   AWS_SECRET_ACCESS_KEY: string
-  S3_BUCKET: string
   S3_ENDPOINT?: string | undefined
   S3_REGION: string
+  S3_BUCKET_ORIGINAL: string
+  S3_BUCKET_CONVERTED: string
 }
 
 // eslint-disable-next-line complexity -- 列挙
@@ -18,7 +19,8 @@ export const extractEnv = (obj: Record<string, string | undefined>): VioletEnv =
   const AWS_SECRET_ACCESS_KEY = obj.MINIO_ROOT_PASSWORD ?? ''
   const S3_REGION = obj.S3_REGION ?? ''
   const S3_ENDPOINT = obj.S3_ENDPOINT || undefined
-  const S3_BUCKET = obj.S3_BUCKET ?? 'violet-app'
+  const S3_BUCKET_ORIGINAL = obj.S3_BUCKET_ORIGINAL ?? ''
+  const S3_BUCKET_CONVERTED = obj.S3_BUCKET_CONVERTED ?? ''
 
   return {
     API_BASE_PATH,
@@ -26,8 +28,9 @@ export const extractEnv = (obj: Record<string, string | undefined>): VioletEnv =
     API_PORT,
     AWS_ACCESS_KEY_ID,
     AWS_SECRET_ACCESS_KEY,
-    S3_BUCKET,
     S3_ENDPOINT,
     S3_REGION,
+    S3_BUCKET_ORIGINAL,
+    S3_BUCKET_CONVERTED,
   }
 }

--- a/pkg/def/envValues.ts
+++ b/pkg/def/envValues.ts
@@ -8,6 +8,8 @@ export interface VioletEnv {
   S3_REGION: string
   S3_BUCKET_ORIGINAL: string
   S3_BUCKET_CONVERTED: string
+  CLOUDWATCH_CRITICAL_LOG_GROUP?: string | undefined
+  PRETTY_LOGGING?: string | undefined
 }
 
 // eslint-disable-next-line complexity -- 列挙
@@ -21,6 +23,8 @@ export const extractEnv = (obj: Record<string, string | undefined>): VioletEnv =
   const S3_ENDPOINT = obj.S3_ENDPOINT || undefined
   const S3_BUCKET_ORIGINAL = obj.S3_BUCKET_ORIGINAL ?? ''
   const S3_BUCKET_CONVERTED = obj.S3_BUCKET_CONVERTED ?? ''
+  const CLOUDWATCH_CRITICAL_LOG_GROUP = obj.CLOUDWATCH_CRITICAL_LOG_GROUP || undefined
+  const PRETTY_LOGGING = obj.PRETTY_LOGGING || undefined
 
   return {
     API_BASE_PATH,
@@ -32,5 +36,7 @@ export const extractEnv = (obj: Record<string, string | undefined>): VioletEnv =
     S3_REGION,
     S3_BUCKET_ORIGINAL,
     S3_BUCKET_CONVERTED,
+    CLOUDWATCH_CRITICAL_LOG_GROUP,
+    PRETTY_LOGGING,
   }
 }

--- a/pkg/lambda/conv2img/package.json
+++ b/pkg/lambda/conv2img/package.json
@@ -15,8 +15,8 @@
     "@violet/scripts": "workspace:*"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.39.0",
-    "@aws-sdk/credential-providers": "^3.39.0",
+    "@aws-sdk/client-s3": "^3.40.0",
+    "@aws-sdk/credential-providers": "^3.40.0",
     "source-map-support": "^0.5.20"
   }
 }

--- a/pkg/lambda/conv2img/package.json
+++ b/pkg/lambda/conv2img/package.json
@@ -15,8 +15,8 @@
     "@violet/scripts": "workspace:*"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.40.0",
-    "@aws-sdk/credential-providers": "^3.40.0",
+    "@aws-sdk/client-s3": "^3.41.0",
+    "@aws-sdk/credential-providers": "^3.41.0",
     "source-map-support": "^0.5.20"
   }
 }

--- a/pkg/lambda/conv2img/src/convert-object.ts
+++ b/pkg/lambda/conv2img/src/convert-object.ts
@@ -91,8 +91,8 @@ export const convertObject = async ({
   const filename = `${Date.now()}-${key.split('/').pop()}`
   const convertedDir = path.join(LOCAL_DIR_NAMES.converted, filename.replace(/\.[^.]+$/, ''))
   fs.mkdirSync(convertedDir, { recursive: true })
+  logger.info('Destination directory created.')
 
-  logger.info('zzz2', await exec('curl', ['ifconfig.co'], false))
   const data = await getObject({ key, env, logger, credentials })
   logger.info('Downloaded object.')
 

--- a/pkg/lambda/conv2img/src/convert-object.ts
+++ b/pkg/lambda/conv2img/src/convert-object.ts
@@ -93,7 +93,7 @@ export const convertObject = async ({
   const convertedDir = path.join(LOCAL_DIR_NAMES.converted, filename.replace(/\.[^.]+$/, ''))
   fs.mkdirSync(convertedDir, { recursive: true })
 
-  logger.info('z1', { credentials })
+  logger.info('z1')
   const s3 = new S3({
     // region: env.S3_REGION,
     credentials,
@@ -102,7 +102,10 @@ export const convertObject = async ({
     // forcePathStyle: true,
   })
   logger.info('z')
-  const r1 = await s3.headObject({ Bucket: bucket, Key: key })
+  logger.info('zzz', await exec('echo', ['hello'], false))
+  logger.info('z2')
+  logger.info('zzz2', await exec('curl', ['ifconfig.co'], false))
+  const r1 = await s3.headObject({ Bucket: '', Key: key })
   logger.info('r1', { r1 })
   const r = await s3.getObject({ Bucket: bucket, Key: key })
   logger.info('r', { r })

--- a/pkg/lambda/conv2img/src/convert-object.ts
+++ b/pkg/lambda/conv2img/src/convert-object.ts
@@ -1,0 +1,170 @@
+import type { Credentials, Provider } from '@aws-sdk/types'
+import { worksConvertedKeyPrefix, worksOriginalKeyPrefix } from '@violet/def/constants/s3'
+import type { VioletEnv } from '@violet/def/envValues'
+import { exec } from '@violet/lib/exec'
+import type { Logger } from '@violet/lib/logger'
+import { replaceKeyPrefix } from '@violet/lib/s3'
+import * as fs from 'fs'
+import type { IncomingMessage } from 'http'
+import * as path from 'path'
+import { getObject, putObject } from './s3'
+
+const CONTENT_TYPES = {
+  webp: 'image/webp',
+  jpg: 'image/jpeg',
+  png: 'image/png',
+} as const
+
+const FALLBACK_EXTS = ['jpg', 'png'] as const
+
+type InfoJson = {
+  fallbackImageExts: typeof FALLBACK_EXTS[number][]
+}
+
+export const LOCAL_DIR_NAMES = {
+  tmp: '/tmp/tmp',
+  original: '/tmp/original',
+  converted: '/tmp/converted',
+} as const
+
+interface ConvertS3DataToPdfParams {
+  data: IncomingMessage
+  filename: string
+}
+const convertS3DataToPdf = ({ data, filename }: ConvertS3DataToPdfParams) =>
+  new Promise<void>((resolve) => {
+    const { dirname, onFinish } = {
+      true: { dirname: LOCAL_DIR_NAMES.original, onFinish: resolve },
+      false: {
+        dirname: LOCAL_DIR_NAMES.tmp,
+        onFinish: () =>
+          exec(
+            'libreoffice',
+            [
+              '--nolockcheck',
+              '--nologo',
+              '--headless',
+              '--norestore',
+              '--language=ja',
+              '--nofirststartwizard',
+              '--convert-to',
+              'pdf',
+              '--outdir',
+              LOCAL_DIR_NAMES.original,
+              path.join(LOCAL_DIR_NAMES.tmp, filename),
+            ],
+            false
+          ).then(() => resolve()),
+      },
+    }[`${filename.endsWith('.pdf')}`]
+
+    const writer = fs.createWriteStream(path.join(dirname, filename))
+    writer.once('finish', onFinish)
+    data.pipe(writer)
+  })
+
+interface ConvertObjectParams {
+  bucket: string
+  key: string
+  env: VioletEnv
+  logger: Logger
+  credentials: Credentials | Provider<Credentials>
+}
+export const convertObject = async ({
+  bucket,
+  key,
+  env,
+  logger,
+  credentials,
+}: ConvertObjectParams): Promise<void> => {
+  Object.values(LOCAL_DIR_NAMES).forEach((name) => fs.mkdirSync(name, { recursive: true }))
+  if (bucket !== env.S3_BUCKET_ORIGINAL) {
+    console.warn(`Ignored bucket s3://${bucket}`)
+    return
+  }
+  const convertedKeyPrefix = replaceKeyPrefix(
+    key.split('/').slice(0, -1).join('/'),
+    worksOriginalKeyPrefix,
+    worksConvertedKeyPrefix
+  )
+
+  const filename = `${Date.now()}-${key.split('/').pop()}`
+  const convertedDir = path.join(LOCAL_DIR_NAMES.converted, filename.replace(/\.[^.]+$/, ''))
+  fs.mkdirSync(convertedDir, { recursive: true })
+
+  const data = await getObject({ key, env, logger, credentials })
+  logger.info('Downloaded object.')
+
+  await convertS3DataToPdf({ data, filename })
+  logger.info('Converted to PDF.')
+
+  for (const ext of FALLBACK_EXTS) {
+    await exec(
+      'convert',
+      [
+        '-density',
+        '400',
+        '-resize',
+        '1280x1280',
+        '-alpha',
+        'remove',
+        '-quality',
+        '85',
+        path.join(LOCAL_DIR_NAMES.original, filename.replace(/[^.]+$/, 'pdf')),
+        path.join(convertedDir, `%d.${ext}`),
+      ],
+      false
+    )
+  }
+  logger.info('Converted fallbacks.')
+
+  // Todo: mozjpeg
+
+  const info: InfoJson = {
+    fallbackImageExts: [...Array(fs.readdirSync(convertedDir).length / FALLBACK_EXTS.length)].map(
+      (_, i) =>
+        FALLBACK_EXTS.map((ext) => ({
+          ext,
+          size: fs.statSync(path.join(convertedDir, `${i}.${ext}`)).size,
+        })).sort((a, b) => a.size - b.size)[0].ext
+    ),
+  }
+
+  for (let i = 0; i < info.fallbackImageExts.length; i += 1) {
+    await exec(
+      'convert',
+      [
+        path.join(convertedDir, `${i}.${info.fallbackImageExts[i]}`),
+        path.join(convertedDir, `${i}.webp`),
+      ],
+      false
+    )
+  }
+  logger.info('Converted to webp.')
+
+  await Promise.all(
+    info.fallbackImageExts.flatMap((ext, i) =>
+      (['webp', ext] as const).map((e) =>
+        putObject({
+          key: `${convertedKeyPrefix}/${i}.${e}`,
+          contentType: CONTENT_TYPES[e],
+          body: fs.readFileSync(path.join(convertedDir, `${i}.${e}`)),
+          env,
+          logger,
+          credentials,
+        })
+      )
+    )
+  )
+  logger.info('Uploaded images.')
+
+  await putObject({
+    key: `${convertedKeyPrefix}/info.json`,
+    contentType: 'application/json',
+    body: JSON.stringify(info),
+    env,
+    logger,
+    credentials,
+  })
+  logger.info('Uploaded info.json.')
+}

--- a/pkg/lambda/conv2img/src/convert-object.ts
+++ b/pkg/lambda/conv2img/src/convert-object.ts
@@ -77,21 +77,28 @@ export const convertObject = async ({
   logger,
   credentials,
 }: ConvertObjectParams): Promise<void> => {
+  logger.info('aaaaaaaaaaaaaaa1111111111111111123')
   Object.values(LOCAL_DIR_NAMES).forEach((name) => fs.mkdirSync(name, { recursive: true }))
+  logger.info('aaaaaaaaaaaaaaa1111111111111111121')
   if (bucket !== env.S3_BUCKET_ORIGINAL) {
     console.warn(`Ignored bucket s3://${bucket}`)
     return
   }
+  logger.info('aaaaaaaaaaaaaaa1111111111111111119')
   const convertedKeyPrefix = replaceKeyPrefix(
     key.split('/').slice(0, -1).join('/'),
     worksOriginalKeyPrefix,
     worksConvertedKeyPrefix
   )
 
+  logger.info('aaaaaaaaaaaaaaa1111111111111111117')
   const filename = `${Date.now()}-${key.split('/').pop()}`
+  logger.info('aaaaaaaaaaaaaaa1111111111111111115')
   const convertedDir = path.join(LOCAL_DIR_NAMES.converted, filename.replace(/\.[^.]+$/, ''))
+  logger.info('aaaaaaaaaaaaaaa1111111111111111113')
   fs.mkdirSync(convertedDir, { recursive: true })
 
+  logger.info('aaaaaaaaaaaaaaa1111111111111111111')
   const data = await getObject({ key, env, logger, credentials })
   logger.info('Downloaded object.')
 

--- a/pkg/lambda/conv2img/src/convert-object.ts
+++ b/pkg/lambda/conv2img/src/convert-object.ts
@@ -1,4 +1,5 @@
 import { S3 } from '@aws-sdk/client-s3'
+import { EC2 } from '@aws-sdk/client-ec2'
 import type { Credentials, Provider } from '@aws-sdk/types'
 import { worksConvertedKeyPrefix, worksOriginalKeyPrefix } from '@violet/def/constants/s3'
 import type { VioletEnv } from '@violet/def/envValues'
@@ -94,6 +95,13 @@ export const convertObject = async ({
   fs.mkdirSync(convertedDir, { recursive: true })
 
   logger.info('z1')
+  const ec2 = new EC2({
+    credentials,
+    logger,
+  })
+  logger.info('z4')
+  logger.info('ec2', await ec2.describeInstances({}));
+  logger.info('z6')
   const s3 = new S3({
     // region: env.S3_REGION,
     credentials,

--- a/pkg/lambda/conv2img/src/convert-object.ts
+++ b/pkg/lambda/conv2img/src/convert-object.ts
@@ -100,6 +100,9 @@ export const convertObject = async ({
     // endpoint: env.S3_ENDPOINT,
     // forcePathStyle: true,
   })
+  logger.info('z')
+  const r1 = await s3.headObject({ Bucket: bucket, Key: key })
+  logger.info('r1', { r1 })
   const r = await s3.getObject({ Bucket: bucket, Key: key })
   logger.info('r', { r })
   const data = await getObject({ key, env, logger, credentials })

--- a/pkg/lambda/conv2img/src/convert-object.ts
+++ b/pkg/lambda/conv2img/src/convert-object.ts
@@ -1,5 +1,3 @@
-import { S3 } from '@aws-sdk/client-s3'
-import { EC2 } from '@aws-sdk/client-ec2'
 import type { Credentials, Provider } from '@aws-sdk/types'
 import { worksConvertedKeyPrefix, worksOriginalKeyPrefix } from '@violet/def/constants/s3'
 import type { VioletEnv } from '@violet/def/envValues'
@@ -94,29 +92,7 @@ export const convertObject = async ({
   const convertedDir = path.join(LOCAL_DIR_NAMES.converted, filename.replace(/\.[^.]+$/, ''))
   fs.mkdirSync(convertedDir, { recursive: true })
 
-  logger.info('z1')
-  const ec2 = new EC2({
-    credentials,
-    logger,
-  })
-  logger.info('z4')
-  logger.info('ec2', await ec2.describeInstances({}));
-  logger.info('z6')
-  const s3 = new S3({
-    // region: env.S3_REGION,
-    credentials,
-    logger,
-    // endpoint: env.S3_ENDPOINT,
-    // forcePathStyle: true,
-  })
-  logger.info('z')
-  logger.info('zzz', await exec('echo', ['hello'], false))
-  logger.info('z2')
   logger.info('zzz2', await exec('curl', ['ifconfig.co'], false))
-  const r1 = await s3.headObject({ Bucket: '', Key: key })
-  logger.info('r1', { r1 })
-  const r = await s3.getObject({ Bucket: bucket, Key: key })
-  logger.info('r', { r })
   const data = await getObject({ key, env, logger, credentials })
   logger.info('Downloaded object.')
 

--- a/pkg/lambda/conv2img/src/convert-object.ts
+++ b/pkg/lambda/conv2img/src/convert-object.ts
@@ -93,6 +93,7 @@ export const convertObject = async ({
   const convertedDir = path.join(LOCAL_DIR_NAMES.converted, filename.replace(/\.[^.]+$/, ''))
   fs.mkdirSync(convertedDir, { recursive: true })
 
+  logger.info('z1', { credentials })
   const s3 = new S3({
     // region: env.S3_REGION,
     credentials,

--- a/pkg/lambda/conv2img/src/convert-object.ts
+++ b/pkg/lambda/conv2img/src/convert-object.ts
@@ -1,3 +1,4 @@
+import { S3 } from '@aws-sdk/client-s3'
 import type { Credentials, Provider } from '@aws-sdk/types'
 import { worksConvertedKeyPrefix, worksOriginalKeyPrefix } from '@violet/def/constants/s3'
 import type { VioletEnv } from '@violet/def/envValues'
@@ -77,28 +78,30 @@ export const convertObject = async ({
   logger,
   credentials,
 }: ConvertObjectParams): Promise<void> => {
-  logger.info('aaaaaaaaaaaaaaa1111111111111111123')
   Object.values(LOCAL_DIR_NAMES).forEach((name) => fs.mkdirSync(name, { recursive: true }))
-  logger.info('aaaaaaaaaaaaaaa1111111111111111121')
   if (bucket !== env.S3_BUCKET_ORIGINAL) {
     console.warn(`Ignored bucket s3://${bucket}`)
     return
   }
-  logger.info('aaaaaaaaaaaaaaa1111111111111111119')
   const convertedKeyPrefix = replaceKeyPrefix(
     key.split('/').slice(0, -1).join('/'),
     worksOriginalKeyPrefix,
     worksConvertedKeyPrefix
   )
 
-  logger.info('aaaaaaaaaaaaaaa1111111111111111117')
   const filename = `${Date.now()}-${key.split('/').pop()}`
-  logger.info('aaaaaaaaaaaaaaa1111111111111111115')
   const convertedDir = path.join(LOCAL_DIR_NAMES.converted, filename.replace(/\.[^.]+$/, ''))
-  logger.info('aaaaaaaaaaaaaaa1111111111111111113')
   fs.mkdirSync(convertedDir, { recursive: true })
 
-  logger.info('aaaaaaaaaaaaaaa1111111111111111111')
+  const s3 = new S3({
+    // region: env.S3_REGION,
+    credentials,
+    logger,
+    // endpoint: env.S3_ENDPOINT,
+    // forcePathStyle: true,
+  })
+  const r = await s3.getObject({ Bucket: bucket, Key: key })
+  logger.info('r', { r })
   const data = await getObject({ key, env, logger, credentials })
   logger.info('Downloaded object.')
 

--- a/pkg/lambda/conv2img/src/credentials.ts
+++ b/pkg/lambda/conv2img/src/credentials.ts
@@ -1,0 +1,13 @@
+import { fromEnv } from '@aws-sdk/credential-providers'
+import type { Credentials, Provider } from '@aws-sdk/types'
+import type { VioletEnv } from '@violet/def/envValues'
+
+export const createCredentials = (env: VioletEnv): Credentials | Provider<Credentials> => {
+  if (env.AWS_ACCESS_KEY_ID) {
+    return {
+      accessKeyId: env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
+    }
+  }
+  return fromEnv()
+}

--- a/pkg/lambda/conv2img/src/credentials.ts
+++ b/pkg/lambda/conv2img/src/credentials.ts
@@ -1,4 +1,4 @@
-import { fromProcess } from '@aws-sdk/credential-providers'
+import { fromEnv } from '@aws-sdk/credential-providers'
 import type { Credentials, Provider } from '@aws-sdk/types'
 import type { VioletEnv } from '@violet/def/envValues'
 
@@ -9,5 +9,5 @@ export const createCredentials = (env: VioletEnv): Credentials | Provider<Creden
       secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
     }
   }
-  return fromProcess()
+  return fromEnv()
 }

--- a/pkg/lambda/conv2img/src/credentials.ts
+++ b/pkg/lambda/conv2img/src/credentials.ts
@@ -1,4 +1,4 @@
-import { fromInstanceMetadata } from '@aws-sdk/credential-providers'
+import { fromProcess } from '@aws-sdk/credential-providers'
 import type { Credentials, Provider } from '@aws-sdk/types'
 import type { VioletEnv } from '@violet/def/envValues'
 
@@ -9,5 +9,5 @@ export const createCredentials = (env: VioletEnv): Credentials | Provider<Creden
       secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
     }
   }
-  return fromInstanceMetadata()
+  return fromProcess()
 }

--- a/pkg/lambda/conv2img/src/credentials.ts
+++ b/pkg/lambda/conv2img/src/credentials.ts
@@ -1,4 +1,4 @@
-import { fromEnv } from '@aws-sdk/credential-providers'
+import { fromContainerMetadata } from '@aws-sdk/credential-providers'
 import type { Credentials, Provider } from '@aws-sdk/types'
 import type { VioletEnv } from '@violet/def/envValues'
 
@@ -9,5 +9,5 @@ export const createCredentials = (env: VioletEnv): Credentials | Provider<Creden
       secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
     }
   }
-  return fromEnv()
+  return fromContainerMetadata()
 }

--- a/pkg/lambda/conv2img/src/credentials.ts
+++ b/pkg/lambda/conv2img/src/credentials.ts
@@ -1,4 +1,4 @@
-import { fromContainerMetadata } from '@aws-sdk/credential-providers'
+import { fromInstanceMetadata } from '@aws-sdk/credential-providers'
 import type { Credentials, Provider } from '@aws-sdk/types'
 import type { VioletEnv } from '@violet/def/envValues'
 
@@ -9,5 +9,5 @@ export const createCredentials = (env: VioletEnv): Credentials | Provider<Creden
       secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
     }
   }
-  return fromContainerMetadata()
+  return fromInstanceMetadata()
 }

--- a/pkg/lambda/conv2img/src/index.ts
+++ b/pkg/lambda/conv2img/src/index.ts
@@ -79,6 +79,7 @@ const convertObject = async (bucket: string, key: string): Promise<void> => {
   fs.mkdirSync(convertedDir, { recursive: true })
 
   await getObject(key).then((data) => convertS3DataToPdf(data, filename))
+  console.log('Downloaded object.');
 
   for (const ext of FALLBACK_EXTS) {
     await exec(
@@ -98,6 +99,7 @@ const convertObject = async (bucket: string, key: string): Promise<void> => {
       false
     )
   }
+  console.log('Converted fallbacks.');
 
   // Todo: mozjpeg
 
@@ -121,6 +123,7 @@ const convertObject = async (bucket: string, key: string): Promise<void> => {
       false
     )
   }
+  console.log('Converted to webp.');
 
   await Promise.all(
     info.fallbackImageExts.flatMap((ext, i) =>
@@ -133,12 +136,14 @@ const convertObject = async (bucket: string, key: string): Promise<void> => {
       )
     )
   )
+  console.log('Uploaded images.');
 
   await putObject(`${convertedKeyPrefix}/info.json`, 'application/json', JSON.stringify(info))
+  console.log('Uploaded info.json.');
 }
 
 export const handler: S3Handler & SQSHandler & SNSHandler = async (event) => {
-  console.log(JSON.stringify({ event }))
+  console.log('Event received.', JSON.stringify({ event }))
   const locations = findS3LocationsInEvent(event)
   if (locations.length === 0) throw new Error('no location found in received event')
   console.log(`Found ${locations.length} location(s).`)

--- a/pkg/lambda/conv2img/src/index.ts
+++ b/pkg/lambda/conv2img/src/index.ts
@@ -1,4 +1,6 @@
+import { worksConvertedKeyPrefix, worksOriginalKeyPrefix } from '@violet/def/constants/s3'
 import { exec } from '@violet/lib/exec'
+import { replaceKeyPrefix } from '@violet/lib/s3'
 import type { S3Handler } from 'aws-lambda'
 import * as fs from 'fs'
 import type { IncomingMessage } from 'http'
@@ -107,7 +109,11 @@ export const handler: S3Handler = async (event) => {
     )
   }
 
-  const convertedKeyPrefix = key.replace(/\/original\/[^/]+$/, '/converted')
+  const convertedKeyPrefix = replaceKeyPrefix(
+    key.split('/').slice(0, -1).join('/'),
+    worksOriginalKeyPrefix,
+    worksConvertedKeyPrefix
+  )
 
   await Promise.all(
     info.fallbackImageExts.flatMap((ext, i) =>

--- a/pkg/lambda/conv2img/src/index.ts
+++ b/pkg/lambda/conv2img/src/index.ts
@@ -1,159 +1,30 @@
-import { worksConvertedKeyPrefix, worksOriginalKeyPrefix } from '@violet/def/constants/s3'
 import { extractEnv } from '@violet/def/envValues'
-import { exec } from '@violet/lib/exec'
 import { findS3LocationsInEvent } from '@violet/lib/lambda/s3'
-import { replaceKeyPrefix } from '@violet/lib/s3'
+import { createChildLogger, createLogger } from '@violet/lib/logger'
 import type { S3Handler, SNSHandler, SQSHandler } from 'aws-lambda'
-import * as fs from 'fs'
-import type { IncomingMessage } from 'http'
-import * as path from 'path'
-import { getObject, putObject } from './s3'
-
-const { S3_BUCKET_ORIGINAL } = extractEnv(process.env)
-
-const CONTENT_TYPES = {
-  webp: 'image/webp',
-  jpg: 'image/jpeg',
-  png: 'image/png',
-} as const
-
-const FALLBACK_EXTS = ['jpg', 'png'] as const
-
-type InfoJson = {
-  fallbackImageExts: typeof FALLBACK_EXTS[number][]
-}
-
-const LOCAL_DIR_NAMES = {
-  tmp: '/tmp/tmp',
-  original: '/tmp/original',
-  converted: '/tmp/converted',
-} as const
-
-const convertS3DataToPdf = (data: IncomingMessage, filename: string) =>
-  new Promise<void>((resolve) => {
-    const { dirname, onFinish } = {
-      true: { dirname: LOCAL_DIR_NAMES.original, onFinish: resolve },
-      false: {
-        dirname: LOCAL_DIR_NAMES.tmp,
-        onFinish: () =>
-          exec(
-            'libreoffice',
-            [
-              '--nolockcheck',
-              '--nologo',
-              '--headless',
-              '--norestore',
-              '--language=ja',
-              '--nofirststartwizard',
-              '--convert-to',
-              'pdf',
-              '--outdir',
-              LOCAL_DIR_NAMES.original,
-              path.join(LOCAL_DIR_NAMES.tmp, filename),
-            ],
-            false
-          ).then(() => resolve()),
-      },
-    }[`${filename.endsWith('.pdf')}`]
-
-    const writer = fs.createWriteStream(path.join(dirname, filename))
-    writer.once('finish', onFinish)
-    data.pipe(writer)
-    console.log('Copied object.')
-  })
-
-const convertObject = async (bucket: string, key: string): Promise<void> => {
-  if (bucket !== S3_BUCKET_ORIGINAL) {
-    console.warn(`Ignored bucket s3://${bucket}`)
-    return
-  }
-  const convertedKeyPrefix = replaceKeyPrefix(
-    key.split('/').slice(0, -1).join('/'),
-    worksOriginalKeyPrefix,
-    worksConvertedKeyPrefix
-  )
-
-  const filename = `${Date.now()}-${key.split('/').pop()}`
-  const convertedDir = path.join(LOCAL_DIR_NAMES.converted, filename.replace(/\.[^.]+$/, ''))
-  fs.mkdirSync(convertedDir, { recursive: true })
-
-  await getObject(key).then((data) => convertS3DataToPdf(data, filename))
-  console.log('Downloaded object and converted to PDF.')
-
-  for (const ext of FALLBACK_EXTS) {
-    await exec(
-      'convert',
-      [
-        '-density',
-        '400',
-        '-resize',
-        '1280x1280',
-        '-alpha',
-        'remove',
-        '-quality',
-        '85',
-        path.join(LOCAL_DIR_NAMES.original, filename.replace(/[^.]+$/, 'pdf')),
-        path.join(convertedDir, `%d.${ext}`),
-      ],
-      false
-    )
-  }
-  console.log('Converted fallbacks.')
-
-  // Todo: mozjpeg
-
-  const info: InfoJson = {
-    fallbackImageExts: [...Array(fs.readdirSync(convertedDir).length / FALLBACK_EXTS.length)].map(
-      (_, i) =>
-        FALLBACK_EXTS.map((ext) => ({
-          ext,
-          size: fs.statSync(path.join(convertedDir, `${i}.${ext}`)).size,
-        })).sort((a, b) => a.size - b.size)[0].ext
-    ),
-  }
-
-  for (let i = 0; i < info.fallbackImageExts.length; i += 1) {
-    await exec(
-      'convert',
-      [
-        path.join(convertedDir, `${i}.${info.fallbackImageExts[i]}`),
-        path.join(convertedDir, `${i}.webp`),
-      ],
-      false
-    )
-  }
-  console.log('Converted to webp.')
-
-  await Promise.all(
-    info.fallbackImageExts.flatMap((ext, i) =>
-      (['webp', ext] as const).map((e) =>
-        putObject(
-          `${convertedKeyPrefix}/${i}.${e}`,
-          CONTENT_TYPES[e],
-          fs.readFileSync(path.join(convertedDir, `${i}.${e}`))
-        )
-      )
-    )
-  )
-  console.log('Uploaded images.')
-
-  await putObject(`${convertedKeyPrefix}/info.json`, 'application/json', JSON.stringify(info))
-  console.log('Uploaded info.json.')
-}
+import { convertObject } from './convert-object'
+import { createCredentials } from './credentials'
 
 export const handler: S3Handler & SQSHandler & SNSHandler = async (event) => {
-  Object.values(LOCAL_DIR_NAMES).forEach((name) => fs.mkdirSync(name, { recursive: true }))
+  const env = extractEnv(process.env)
+  const credentials = createCredentials(env)
+  const logger = createLogger({ env, credentials, service: 'conv2img' })
 
-  console.log('Event received.', JSON.stringify({ event }))
+  logger.info('Event received.', { event })
   const locations = findS3LocationsInEvent(event)
   if (locations.length === 0) throw new Error('no location found in received event')
-  console.log(`Found ${locations.length} location(s).`)
+  logger.info(`Found ${locations.length} location(s).`)
   let failCount = 0
   for (const { key, bucket } of locations) {
-    console.log(`s3://${bucket}/${key} is found in event.`)
-    await convertObject(bucket, key).catch((err: unknown) => {
-      console.error(`Failed to convert s3://${bucket}/${key}`)
-      console.error(err)
+    logger.info(`s3://${bucket}/${key} is found in event.`)
+    await convertObject({
+      bucket,
+      key,
+      env,
+      logger: createChildLogger(logger, key),
+      credentials,
+    }).catch((err: unknown) => {
+      logger.error(`Failed to convert s3://${bucket}/${key}`, { err })
       failCount += 1
     })
   }

--- a/pkg/lambda/conv2img/src/index.ts
+++ b/pkg/lambda/conv2img/src/index.ts
@@ -9,7 +9,6 @@ export const handler: S3Handler & SQSHandler & SNSHandler = async (event) => {
   const env = extractEnv(process.env)
   const credentials = createCredentials(env)
   const logger = createLogger({ env, credentials, service: 'conv2img' })
-  logger.info('Env', { env: process.env })
 
   logger.info('Event received.', { event })
   const locations = findS3LocationsInEvent(event)

--- a/pkg/lambda/conv2img/src/index.ts
+++ b/pkg/lambda/conv2img/src/index.ts
@@ -138,9 +138,12 @@ const convertObject = async (bucket: string, key: string): Promise<void> => {
 }
 
 export const handler: S3Handler & SQSHandler & SNSHandler = async (event) => {
-  console.log({ event })
+  console.log(JSON.stringify({ event }))
+  const locations = findS3LocationsInEvent(event)
+  if (locations.length === 0) throw new Error('no location found in received event')
+  console.log(`Found ${locations.length} location(s).`)
   let failCount = 0
-  for (const { key, bucket } of findS3LocationsInEvent(event)) {
+  for (const { key, bucket } of locations) {
     console.log(`s3://${bucket}/${key} is found in event.`)
     await convertObject(bucket, key).catch((err: unknown) => {
       console.error(`Failed to convert s3://${bucket}/${key}`)

--- a/pkg/lambda/conv2img/src/index.ts
+++ b/pkg/lambda/conv2img/src/index.ts
@@ -9,6 +9,7 @@ export const handler: S3Handler & SQSHandler & SNSHandler = async (event) => {
   const env = extractEnv(process.env)
   const credentials = createCredentials(env)
   const logger = createLogger({ env, credentials, service: 'conv2img' })
+  logger.info('Env', { env: process.env })
 
   logger.info('Event received.', { event })
   const locations = findS3LocationsInEvent(event)
@@ -24,7 +25,7 @@ export const handler: S3Handler & SQSHandler & SNSHandler = async (event) => {
       logger: createChildLogger(logger, key),
       credentials,
     }).catch((err: unknown) => {
-      logger.error(`Failed to convert s3://${bucket}/${key}`, { err })
+      logger.error(`Failed to convert s3://${bucket}/${key}`, { err, errMessage: String(err) })
       failCount += 1
     })
   }

--- a/pkg/lambda/conv2img/src/s3.ts
+++ b/pkg/lambda/conv2img/src/s3.ts
@@ -1,3 +1,4 @@
+import type { GetObjectCommandInput } from '@aws-sdk/client-s3'
 import { S3 } from '@aws-sdk/client-s3'
 import type { Credentials, Provider } from '@aws-sdk/types'
 import type { VioletEnv } from '@violet/def/envValues'
@@ -9,7 +10,7 @@ interface CreateS3ClientParams {
   credentials: Credentials | Provider<Credentials>
   logger: Logger
 }
-const createS3Client = ({ env, logger, credentials }: CreateS3ClientParams) => {
+export const createS3Client = ({ env, logger, credentials }: CreateS3ClientParams) => {
   return new S3({
     region: env.S3_REGION,
     credentials,
@@ -19,42 +20,9 @@ const createS3Client = ({ env, logger, credentials }: CreateS3ClientParams) => {
   })
 }
 
-interface GetObjectParams {
-  key: string
-  env: VioletEnv
-  credentials: Credentials | Provider<Credentials>
-  logger: Logger
-}
-export const getObject = ({ key, env, logger, credentials }: GetObjectParams) =>
-  createS3Client({ env, credentials, logger })
-    .getObject({ Bucket: env.S3_BUCKET_ORIGINAL, Key: key })
-    .then(({ Body }) => {
-      if (Body instanceof IncomingMessage) return Body
+export const getObject = (s3: S3, input: GetObjectCommandInput) =>
+  s3.getObject(input).then(({ Body }) => {
+    if (Body instanceof IncomingMessage) return Body
 
-      throw new Error('Body of getObject is not IncomingMessage')
-    })
-
-interface PutObjectParams {
-  key: string
-  contentType: string
-  body: Buffer | string
-  env: VioletEnv
-  credentials: Credentials | Provider<Credentials>
-  logger: Logger
-}
-export const putObject = async ({
-  key,
-  body,
-  env,
-  logger,
-  credentials,
-  contentType,
-}: PutObjectParams) =>
-  createS3Client({ env, logger, credentials })
-    .putObject({
-      Bucket: env.S3_BUCKET_CONVERTED,
-      Key: key,
-      ContentType: contentType,
-      Body: body,
-    })
-    .then((res) => res.$metadata)
+    throw new Error('Body of getObject is not IncomingMessage')
+  })

--- a/pkg/lambda/conv2img/src/s3.ts
+++ b/pkg/lambda/conv2img/src/s3.ts
@@ -1,59 +1,60 @@
-import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
-import { fromEnv } from '@aws-sdk/credential-providers'
+import { S3 } from '@aws-sdk/client-s3'
 import type { Credentials, Provider } from '@aws-sdk/types'
-import { extractEnv } from '@violet/def/envValues'
+import type { VioletEnv } from '@violet/def/envValues'
+import type { Logger } from '@violet/lib/logger'
 import { IncomingMessage } from 'http'
-const {
-  AWS_ACCESS_KEY_ID,
-  AWS_SECRET_ACCESS_KEY,
-  S3_BUCKET_ORIGINAL,
-  S3_BUCKET_CONVERTED,
-  S3_ENDPOINT,
-  S3_REGION,
-} = extractEnv(process.env)
 
-const getCredentials = (): Credentials | Provider<Credentials> => {
-  if (AWS_ACCESS_KEY_ID) {
-    return {
-      accessKeyId: AWS_ACCESS_KEY_ID,
-      secretAccessKey: AWS_SECRET_ACCESS_KEY,
-    }
-  }
-  return fromEnv()
+interface CreateS3ClientParams {
+  env: VioletEnv
+  credentials: Credentials | Provider<Credentials>
+  logger: Logger
+}
+const createS3Client = ({ env, logger, credentials }: CreateS3ClientParams) => {
+  return new S3({
+    region: env.S3_REGION,
+    credentials,
+    logger,
+    endpoint: env.S3_ENDPOINT,
+    forcePathStyle: true,
+  })
 }
 
-let s3Client: S3Client
-
-const getS3Client = () => {
-  s3Client =
-    s3Client ??
-    new S3Client({
-      region: S3_REGION,
-      credentials: getCredentials(),
-      endpoint: S3_ENDPOINT,
-      forcePathStyle: true,
-    })
-
-  return s3Client
+interface GetObjectParams {
+  key: string
+  env: VioletEnv
+  credentials: Credentials | Provider<Credentials>
+  logger: Logger
 }
-
-export const getObject = (key: string) =>
-  getS3Client()
-    .send(new GetObjectCommand({ Bucket: S3_BUCKET_ORIGINAL, Key: key }))
+export const getObject = ({ key, env, logger, credentials }: GetObjectParams) =>
+  createS3Client({ env, credentials, logger })
+    .getObject({ Bucket: env.S3_BUCKET_ORIGINAL, Key: key })
     .then(({ Body }) => {
       if (Body instanceof IncomingMessage) return Body
 
       throw new Error('Body of getObject is not IncomingMessage')
     })
 
-export const putObject = async (key: string, contentType: string, body: Buffer | string) =>
-  getS3Client()
-    .send(
-      new PutObjectCommand({
-        Bucket: S3_BUCKET_CONVERTED,
-        Key: key,
-        ContentType: contentType,
-        Body: body,
-      })
-    )
+interface PutObjectParams {
+  key: string
+  contentType: string
+  body: Buffer | string
+  env: VioletEnv
+  credentials: Credentials | Provider<Credentials>
+  logger: Logger
+}
+export const putObject = async ({
+  key,
+  body,
+  env,
+  logger,
+  credentials,
+  contentType,
+}: PutObjectParams) =>
+  createS3Client({ env, logger, credentials })
+    .putObject({
+      Bucket: env.S3_BUCKET_CONVERTED,
+      Key: key,
+      ContentType: contentType,
+      Body: body,
+    })
     .then((res) => res.$metadata)

--- a/pkg/lib/lambda/s3.ts
+++ b/pkg/lib/lambda/s3.ts
@@ -12,6 +12,16 @@ interface S3ObjectLocation {
   key: string
 }
 
+export const findS3Locations = (
+  obj: S3Event | SQSEvent | SNSEvent | S3EventRecord | SQSRecord | SNSEventRecord
+): S3ObjectLocation[] => {
+  if ('Records' in obj) {
+    return findS3LocationsInEvent(obj)
+  } else {
+    return findS3LocationsInRecord(obj)
+  }
+}
+
 export const findS3LocationsInEvent = (
   event: S3Event | SQSEvent | SNSEvent
 ): S3ObjectLocation[] => {
@@ -30,9 +40,9 @@ export const findS3LocationsInRecord = (
       },
     ]
   } else if ('Sns' in record) {
-    return findS3LocationsInRecord(JSON.parse(record.Sns.Message))
+    return findS3Locations(JSON.parse(record.Sns.Message))
   } else if ('body' in record) {
-    return findS3LocationsInRecord(JSON.parse(record.body))
+    return findS3Locations(JSON.parse(record.body))
   }
   return []
 }

--- a/pkg/lib/lambda/s3.ts
+++ b/pkg/lib/lambda/s3.ts
@@ -1,0 +1,38 @@
+import type {
+  S3Event,
+  S3EventRecord,
+  SNSEvent,
+  SNSEventRecord,
+  SQSEvent,
+  SQSRecord,
+} from 'aws-lambda'
+
+interface S3ObjectLocation {
+  bucket: string
+  key: string
+}
+
+export const findS3LocationsInEvent = (
+  event: S3Event | SQSEvent | SNSEvent
+): S3ObjectLocation[] => {
+  return event.Records.flatMap(findS3LocationsInRecord)
+}
+
+export const findS3LocationsInRecord = (
+  record: S3EventRecord | SQSRecord | SNSEventRecord
+): S3ObjectLocation[] => {
+  if ('s3' in record) {
+    return [
+      {
+        bucket: record.s3.bucket.name,
+        // https://docs.aws.amazon.com/lambda/latest/dg/with-s3-tutorial.html#with-s3-tutorial-create-function-code
+        key: decodeURIComponent(record.s3.object.key.replace(/\+/g, ' ')),
+      },
+    ]
+  } else if ('Sns' in record) {
+    return findS3LocationsInRecord(JSON.parse(record.Sns.Message))
+  } else if ('body' in record) {
+    return findS3LocationsInRecord(JSON.parse(record.body))
+  }
+  return []
+}

--- a/pkg/lib/logger/index.ts
+++ b/pkg/lib/logger/index.ts
@@ -1,0 +1,49 @@
+import type { Credentials, Provider } from '@aws-sdk/types'
+import type { VioletEnv } from '@violet/def/envValues'
+import stringify from 'safe-stable-stringify'
+import type { Logger } from 'winston'
+import * as winston from 'winston'
+
+export type { Logger }
+
+const replacer = (_key: string, value: unknown): unknown => {
+  if (value instanceof Buffer) return value.toString('base64')
+  if (value instanceof Set) return `Set(${[...value].join(', ')})`
+  if (typeof value === 'bigint') return value.toString()
+  return value
+}
+
+export const cloudwatchLogsFormat = winston.format.printf((info) => {
+  return `${info.level}: ${info.message} ${stringify(info, replacer)}`
+})
+
+export interface CreateLoggerParams {
+  env: VioletEnv
+  credentials: Credentials | Provider<Credentials>
+  service: string
+}
+export const createLogger = ({ env, service }: CreateLoggerParams): Logger => {
+  const logger = winston.createLogger({
+    level: 'debug',
+    defaultMeta: { service: [service] },
+  })
+
+  logger.add(
+    new winston.transports.Console({
+      level: 'debug',
+      format: env.PRETTY_LOGGING === '1' ? winston.format.prettyPrint() : cloudwatchLogsFormat,
+    })
+  )
+
+  if (env.CLOUDWATCH_CRITICAL_LOG_GROUP) {
+    // const cloudWatchLogs = new CloudWatchLogs({ credentials })
+    // TODO: critical level logging
+  }
+
+  return logger
+}
+
+export const createChildLogger = (logger: Logger, name: string): Logger =>
+  logger.child({
+    service: [...logger.defaultMeta.service, name],
+  })

--- a/pkg/lib/package.json
+++ b/pkg/lib/package.json
@@ -7,7 +7,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "^3.41.0",
-    "@aws-sdk/client-ec2": "^3.41.0",
     "ballvalve": "^3.1.3",
     "safe-stable-stringify": "^2.2.0",
     "winston": "^3.3.3"

--- a/pkg/lib/package.json
+++ b/pkg/lib/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "^3.41.0",
+    "@aws-sdk/client-ec2": "^3.41.0",
     "ballvalve": "^3.1.3",
     "safe-stable-stringify": "^2.2.0",
     "winston": "^3.3.3"

--- a/pkg/lib/package.json
+++ b/pkg/lib/package.json
@@ -9,6 +9,7 @@
     "ballvalve": "^3.1.3"
   },
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.84",
     "@violet/def": "workspace:*",
     "@violet/lib": "workspace:*"
   }

--- a/pkg/lib/package.json
+++ b/pkg/lib/package.json
@@ -6,7 +6,10 @@
     "_:typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "ballvalve": "^3.1.3"
+    "@aws-sdk/client-cloudwatch-logs": "^3.41.0",
+    "ballvalve": "^3.1.3",
+    "safe-stable-stringify": "^2.2.0",
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.84",

--- a/pkg/lib/s3.ts
+++ b/pkg/lib/s3.ts
@@ -1,5 +1,5 @@
 export const replaceKeyPrefix = (key: string, before: string, after: string): string => {
   if (!key.startsWith(`${before}/`))
     throw new Error(`Key "${key}" is not started with "${before}/"`)
-  return `${after}/${key.slice(before.length + 1)}`
+  return `${after}${key.slice(before.length)}`
 }

--- a/pkg/lib/s3.ts
+++ b/pkg/lib/s3.ts
@@ -1,0 +1,5 @@
+export const replaceKeyPrefix = (key: string, before: string, after: string): string => {
+  if (!key.startsWith(`${before}/`))
+    throw new Error(`Key "${key}" is not started with "${before}/"`)
+  return `${after}/${key.slice(before.length + 1)}`
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,12 +176,14 @@ importers:
 
   pkg/lib:
     specifiers:
+      '@types/aws-lambda': ^8.10.84
       '@violet/def': workspace:*
       '@violet/lib': workspace:*
       ballvalve: ^3.1.3
     dependencies:
       ballvalve: 3.1.3
     devDependencies:
+      '@types/aws-lambda': 8.10.85
       '@violet/def': link:../def
       '@violet/lib': 'link:'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,8 +153,8 @@ importers:
 
   pkg/lambda/conv2img:
     specifiers:
-      '@aws-sdk/client-s3': ^3.39.0
-      '@aws-sdk/credential-providers': ^3.39.0
+      '@aws-sdk/client-s3': ^3.40.0
+      '@aws-sdk/credential-providers': ^3.40.0
       '@types/aws-lambda': ^8.10.84
       '@types/node': ^16.7.5
       '@violet/def': workspace:*
@@ -163,8 +163,8 @@ importers:
       '@violet/scripts': workspace:*
       source-map-support: ^0.5.20
     dependencies:
-      '@aws-sdk/client-s3': 3.39.0
-      '@aws-sdk/credential-providers': 3.39.0
+      '@aws-sdk/client-s3': 3.41.0
+      '@aws-sdk/credential-providers': 3.41.0
       source-map-support: 0.5.20
     devDependencies:
       '@types/aws-lambda': 8.10.85
@@ -259,7 +259,7 @@ packages:
     resolution: {integrity: sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==}
     dependencies:
       '@aws-crypto/util': 2.0.0
-      '@aws-sdk/types': 3.38.0
+      '@aws-sdk/types': 3.40.0
       tslib: 1.14.1
     dev: false
 
@@ -407,6 +407,43 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/client-cognito-identity/3.41.0:
+    resolution: {integrity: sha512-rmlVJi75hLTeUoflafkyINSGD58du7XxxICbT2LGUkkqptfp/y0MViX8kgbymBMs7PdNcyDvevUCzGW6Zdhu0A==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 2.0.0
+      '@aws-crypto/sha256-js': 2.0.0
+      '@aws-sdk/client-sts': 3.41.0
+      '@aws-sdk/config-resolver': 3.40.0
+      '@aws-sdk/credential-provider-node': 3.41.0
+      '@aws-sdk/fetch-http-handler': 3.40.0
+      '@aws-sdk/hash-node': 3.40.0
+      '@aws-sdk/invalid-dependency': 3.40.0
+      '@aws-sdk/middleware-content-length': 3.40.0
+      '@aws-sdk/middleware-host-header': 3.40.0
+      '@aws-sdk/middleware-logger': 3.40.0
+      '@aws-sdk/middleware-retry': 3.40.0
+      '@aws-sdk/middleware-serde': 3.40.0
+      '@aws-sdk/middleware-signing': 3.40.0
+      '@aws-sdk/middleware-stack': 3.40.0
+      '@aws-sdk/middleware-user-agent': 3.40.0
+      '@aws-sdk/node-config-provider': 3.40.0
+      '@aws-sdk/node-http-handler': 3.40.0
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/smithy-client': 3.41.0
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/url-parser': 3.40.0
+      '@aws-sdk/util-base64-browser': 3.37.0
+      '@aws-sdk/util-base64-node': 3.37.0
+      '@aws-sdk/util-body-length-browser': 3.37.0
+      '@aws-sdk/util-body-length-node': 3.37.0
+      '@aws-sdk/util-user-agent-browser': 3.40.0
+      '@aws-sdk/util-user-agent-node': 3.40.0
+      '@aws-sdk/util-utf8-browser': 3.37.0
+      '@aws-sdk/util-utf8-node': 3.37.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/client-s3/3.39.0:
     resolution: {integrity: sha512-FQNJ9IWhpZtd9+if2T2vVHdyqFFytX2l26R4RuBzNLO8XKR0CS++gksbg8X7G5e0ETmltofHoqvay6NvddhZVA==}
     engines: {node: '>=10.0.0'}
@@ -454,6 +491,61 @@ packages:
       '@aws-sdk/util-utf8-browser': 3.37.0
       '@aws-sdk/util-utf8-node': 3.37.0
       '@aws-sdk/util-waiter': 3.38.0
+      '@aws-sdk/xml-builder': 3.37.0
+      entities: 2.2.0
+      fast-xml-parser: 3.19.0
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - '@aws-sdk/signature-v4-crt'
+    dev: false
+
+  /@aws-sdk/client-s3/3.41.0:
+    resolution: {integrity: sha512-PGPy7MbyjkpQECPR02NOxucqJWJEah9IcQcUMyRB1vZBg6irBI1d4GTuWafegr3xKQ+7ZTraupDtUSJ9oRqKOg==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 2.0.0
+      '@aws-crypto/sha256-js': 2.0.0
+      '@aws-sdk/client-sts': 3.41.0
+      '@aws-sdk/config-resolver': 3.40.0
+      '@aws-sdk/credential-provider-node': 3.41.0
+      '@aws-sdk/eventstream-serde-browser': 3.40.0
+      '@aws-sdk/eventstream-serde-config-resolver': 3.40.0
+      '@aws-sdk/eventstream-serde-node': 3.40.0
+      '@aws-sdk/fetch-http-handler': 3.40.0
+      '@aws-sdk/hash-blob-browser': 3.40.0
+      '@aws-sdk/hash-node': 3.40.0
+      '@aws-sdk/hash-stream-node': 3.40.0
+      '@aws-sdk/invalid-dependency': 3.40.0
+      '@aws-sdk/md5-js': 3.40.0
+      '@aws-sdk/middleware-apply-body-checksum': 3.40.0
+      '@aws-sdk/middleware-bucket-endpoint': 3.41.0
+      '@aws-sdk/middleware-content-length': 3.40.0
+      '@aws-sdk/middleware-expect-continue': 3.40.0
+      '@aws-sdk/middleware-host-header': 3.40.0
+      '@aws-sdk/middleware-location-constraint': 3.40.0
+      '@aws-sdk/middleware-logger': 3.40.0
+      '@aws-sdk/middleware-retry': 3.40.0
+      '@aws-sdk/middleware-sdk-s3': 3.41.0
+      '@aws-sdk/middleware-serde': 3.40.0
+      '@aws-sdk/middleware-signing': 3.40.0
+      '@aws-sdk/middleware-ssec': 3.40.0
+      '@aws-sdk/middleware-stack': 3.40.0
+      '@aws-sdk/middleware-user-agent': 3.40.0
+      '@aws-sdk/node-config-provider': 3.40.0
+      '@aws-sdk/node-http-handler': 3.40.0
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/smithy-client': 3.41.0
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/url-parser': 3.40.0
+      '@aws-sdk/util-base64-browser': 3.37.0
+      '@aws-sdk/util-base64-node': 3.37.0
+      '@aws-sdk/util-body-length-browser': 3.37.0
+      '@aws-sdk/util-body-length-node': 3.37.0
+      '@aws-sdk/util-user-agent-browser': 3.40.0
+      '@aws-sdk/util-user-agent-node': 3.40.0
+      '@aws-sdk/util-utf8-browser': 3.37.0
+      '@aws-sdk/util-utf8-node': 3.37.0
+      '@aws-sdk/util-waiter': 3.40.0
       '@aws-sdk/xml-builder': 3.37.0
       entities: 2.2.0
       fast-xml-parser: 3.19.0
@@ -634,6 +726,16 @@ packages:
       '@aws-sdk/client-cognito-identity': 3.39.0
       '@aws-sdk/property-provider': 3.38.0
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/credential-provider-cognito-identity/3.41.0:
+    resolution: {integrity: sha512-cwndWlbO2GJrnqHXQqekVmC7oZw6ELfaivaVtk4zd7iA94B5SjNIm9qGzUKcwvNCM1lezSWn8bluvRMX+jlk4w==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/client-cognito-identity': 3.41.0
+      '@aws-sdk/property-provider': 3.40.0
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -826,11 +928,41 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/credential-providers/3.41.0:
+    resolution: {integrity: sha512-D4mGPg+j7lP6QMzshwhj/DaOKV6f337VhldzNvdlc1oWmE/n33Ru+iBIThhbaeCXYVTCTEAknrKRUgYuYZAhKQ==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/client-cognito-identity': 3.41.0
+      '@aws-sdk/client-sso': 3.41.0
+      '@aws-sdk/client-sts': 3.41.0
+      '@aws-sdk/credential-provider-cognito-identity': 3.41.0
+      '@aws-sdk/credential-provider-env': 3.40.0
+      '@aws-sdk/credential-provider-imds': 3.40.0
+      '@aws-sdk/credential-provider-ini': 3.41.0
+      '@aws-sdk/credential-provider-process': 3.40.0
+      '@aws-sdk/credential-provider-sso': 3.41.0
+      '@aws-sdk/credential-provider-web-identity': 3.41.0
+      '@aws-sdk/property-provider': 3.40.0
+      '@aws-sdk/shared-ini-file-loader': 3.37.0
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/util-credentials': 3.37.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/eventstream-marshaller/3.39.0:
     resolution: {integrity: sha512-L6sSixpE3O9YCfBT2UoCM/p5zgMhVJcd5Ih9dkTDGD1Fi3TFu21tz9GNUrk6oY0J32S0VDkMdLMXnDbbghf9lQ==}
     dependencies:
       '@aws-crypto/crc32': 2.0.0
       '@aws-sdk/types': 3.38.0
+      '@aws-sdk/util-hex-encoding': 3.37.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/eventstream-marshaller/3.40.0:
+    resolution: {integrity: sha512-zHGchfkG3B9M8OOKRpByeS5g1/15YQ0+QQHwxQRtm/CPtKBAIAsCZRQaCNBLu9uQMtBBKj5JsDUcjirhGeSvIg==}
+    dependencies:
+      '@aws-crypto/crc32': 2.0.0
+      '@aws-sdk/types': 3.40.0
       '@aws-sdk/util-hex-encoding': 3.37.0
       tslib: 2.3.1
     dev: false
@@ -845,11 +977,29 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/eventstream-serde-browser/3.40.0:
+    resolution: {integrity: sha512-V0AXAfSkhY0hgxDJ0cNA+r42kL8295U7UTCp2Q2fvCaob3wKWh+54KZ2L4IOYTlK3yNzXJ5V6PP1zUuRlsUTew==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/eventstream-marshaller': 3.40.0
+      '@aws-sdk/eventstream-serde-universal': 3.40.0
+      '@aws-sdk/types': 3.40.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/eventstream-serde-config-resolver/3.38.0:
     resolution: {integrity: sha512-IuA17V0xktmSDGPtKjyrTqo7ysdWkcHrC9DjeKO+tWjvIgoG8pJ1i/BtSU7CKfdB9GygN3FP+NwE+YlyiriDhQ==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/eventstream-serde-config-resolver/3.40.0:
+    resolution: {integrity: sha512-GgGiJBsQ1/SBTpRM/wCdFBCMo1Nybvy46bNVkH1ujCdp8UTLc5PozzNpH+15V2IQbc9sPDYffMab6HSFjDp5vw==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -863,12 +1013,31 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/eventstream-serde-node/3.40.0:
+    resolution: {integrity: sha512-CnzX/JZGvhWlg+ooIPVZ78T+5wIm5Ld1BD7jwhlptJa8IjTMvkc8Nh4pAhc7T0ZScy4zZa/oTkqeVYCOVCyd1Q==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/eventstream-marshaller': 3.40.0
+      '@aws-sdk/eventstream-serde-universal': 3.40.0
+      '@aws-sdk/types': 3.40.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/eventstream-serde-universal/3.39.0:
     resolution: {integrity: sha512-J6O/mspnMZq6lGl+lNsLHTZ4sqEid7eN+1NxcnFhMdZlOaPh9H9tNVQlCeSbQn6PfAR+4cdumkyKXVXt+9RDTA==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/eventstream-marshaller': 3.39.0
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/eventstream-serde-universal/3.40.0:
+    resolution: {integrity: sha512-rkHwVMyZJMhp9iBixkuaAGQNer/DPxZ9kxDDtE+LuAMhepTYQ8c4lUW0QQhYbNMWf48QKD1G4FV3JXIj9JfP9A==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/eventstream-marshaller': 3.40.0
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -901,6 +1070,15 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/hash-blob-browser/3.40.0:
+    resolution: {integrity: sha512-l8xyprVVKKH+720VrQ677X6VkvHttDXB4MxkMuxhSvwYBQwsRzP2Wppo7xIAtWGoS+oqlLmD4LCbHdhFRcN5yA==}
+    dependencies:
+      '@aws-sdk/chunked-blob-reader': 3.37.0
+      '@aws-sdk/chunked-blob-reader-native': 3.37.0
+      '@aws-sdk/types': 3.40.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/hash-node/3.38.0:
     resolution: {integrity: sha512-IRxBx2KDsu/lK0/d411UzxvR1FctZ9vz5L5UnULA0SVGPti3kxCQOSmk9eFdvxRZgp0+AByDCKmAZJrcYKNDqg==}
     engines: {node: '>= 10.0.0'}
@@ -924,6 +1102,14 @@ packages:
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/hash-stream-node/3.40.0:
+    resolution: {integrity: sha512-4yvRwODMGYtj6qrt+fyydV5MwVwPPoyoeqDoXdLo9x75vRY71DT1pMRt8PDOoY/ZwWbIdEt4+V7x0sLt2uy9WA==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -957,6 +1143,15 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/md5-js/3.40.0:
+    resolution: {integrity: sha512-P1tzEljMD/MkjSc00TkVBYvfaVv/7S+04YEwE7tpu/jtxWxMHnk3CMKqq/F2iMhY83DRoqoYy+YqnaF4Bzr1uA==}
+    dependencies:
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/util-utf8-browser': 3.37.0
+      '@aws-sdk/util-utf8-node': 3.37.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/middleware-apply-body-checksum/3.38.0:
     resolution: {integrity: sha512-aQ8ndDFZj0PK6pS2FuUQAA9DvuOt4kfX4VLr9Fl74swyFqnrSvm/oUBTpUMguSpys6CD/vgJiY0pDaQkHKPxTA==}
     engines: {node: '>= 10.0.0'}
@@ -967,6 +1162,16 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/middleware-apply-body-checksum/3.40.0:
+    resolution: {integrity: sha512-gNSFlFu/O8cxAM0X64OwiLLN/NPXvK3FsAIJRsfhIW+dX0bEq4lsGPsdU8Tx+9eenaj/Z01uqgWZ6Izar8zVvQ==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/is-array-buffer': 3.37.0
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/types': 3.40.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/middleware-bucket-endpoint/3.39.0:
     resolution: {integrity: sha512-Iv8wIsgE7lV+Ln3TFpZaJKmzmDkQPf30afNKuu063Gfa5PgSvDWtCjnJn6TXSGo4ND1NLPihCq8gshlc3M8F+A==}
     engines: {node: '>= 10.0.0'}
@@ -974,6 +1179,17 @@ packages:
       '@aws-sdk/protocol-http': 3.38.0
       '@aws-sdk/types': 3.38.0
       '@aws-sdk/util-arn-parser': 3.37.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/middleware-bucket-endpoint/3.41.0:
+    resolution: {integrity: sha512-4A0kWHH2qemd4P7CZKS7XB6qtSUP2xMJ7Dn/llxYgvadR0mKEfGPeYPhAss/k7T1JGv+kSTIV30RwUXwdXgE/A==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/util-arn-parser': 3.37.0
+      '@aws-sdk/util-config-provider': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -1005,12 +1221,31 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/middleware-expect-continue/3.40.0:
+    resolution: {integrity: sha512-FY6vT0u1ptDZ2bBj1yG/Iyk6HZB7U9fbrpeZNPYzgq8HJxBcTgfLwtB3VLobyhThQm9X2a7R2YZrwtArW8yQfQ==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/middleware-header-default': 3.40.0
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/types': 3.40.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/middleware-header-default/3.38.0:
     resolution: {integrity: sha512-PlKarclVCf4olPUrjuxdxv6uS9WSGGV0dmyyn5Ep32iGwx9CXMkrSxql7lPb/7RE/ZHNCCJo+EpARs18wBsGXQ==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/protocol-http': 3.38.0
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/middleware-header-default/3.40.0:
+    resolution: {integrity: sha512-eXQ13x/AivPZKoG8/akp9g5xdNHuKftl83GMuk9K6tt4+eAa22TdxiFu4R0UVlKAvo2feqxFrNs5DhhhBeAQWA==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -1037,6 +1272,14 @@ packages:
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/middleware-location-constraint/3.40.0:
+    resolution: {integrity: sha512-9XaVPYsDQVJbWJH96sNdv4HHY3j1raman+lYxMu4528Awp0OdWUeSsGRYRN+CnRPlkHnfNw4m6SKdWYHxdjshw==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -1087,6 +1330,19 @@ packages:
       '@aws-sdk/protocol-http': 3.38.0
       '@aws-sdk/signature-v4': 3.39.0
       '@aws-sdk/types': 3.38.0
+      '@aws-sdk/util-arn-parser': 3.37.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/middleware-sdk-s3/3.41.0:
+    resolution: {integrity: sha512-B7JOpmIpm1zxERQEMwZCWj3FisTvwfUgpfQglYdqrB6VpIoCM8fk2pmi5KzU/JDeNBlhTouj6mwnhJL/z5jopA==}
+    engines: {node: '>= 10.0.0'}
+    peerDependencies:
+      '@aws-sdk/signature-v4-crt': ^3.31.0
+    dependencies:
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/signature-v4': 3.40.0
+      '@aws-sdk/types': 3.40.0
       '@aws-sdk/util-arn-parser': 3.37.0
       tslib: 2.3.1
     dev: false
@@ -1158,6 +1414,14 @@ packages:
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/middleware-ssec/3.40.0:
+    resolution: {integrity: sha512-ZoRpaZeAIQa1Q+NyEh74ATwOR3nFGfcP6Nu0jFzgqoVijCReMnhtlCRx23ccBu1ZLZNUsNk6MhKjY+ZTfNsjEg==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -1551,6 +1815,15 @@ packages:
     dependencies:
       '@aws-sdk/abort-controller': 3.38.0
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/util-waiter/3.40.0:
+    resolution: {integrity: sha512-jdxwNEZdID49ZvyAnxaeNm5w2moIfMLOwj/q6TxKlxYoXMs16FQWkhyfGue0vEASzchS49ewbyt+KBqpT31Ebg==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/abort-controller': 3.40.0
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,12 +176,18 @@ importers:
 
   pkg/lib:
     specifiers:
+      '@aws-sdk/client-cloudwatch-logs': ^3.41.0
       '@types/aws-lambda': ^8.10.84
       '@violet/def': workspace:*
       '@violet/lib': workspace:*
       ballvalve: ^3.1.3
+      safe-stable-stringify: ^2.2.0
+      winston: ^3.3.3
     dependencies:
+      '@aws-sdk/client-cloudwatch-logs': 3.41.0
       ballvalve: 3.1.3
+      safe-stable-stringify: 2.2.0
+      winston: 3.3.3
     devDependencies:
       '@types/aws-lambda': 8.10.85
       '@violet/def': link:../def
@@ -270,7 +276,7 @@ packages:
       '@aws-crypto/sha256-js': 2.0.0
       '@aws-crypto/supports-web-crypto': 2.0.0
       '@aws-crypto/util': 2.0.0
-      '@aws-sdk/types': 3.38.0
+      '@aws-sdk/types': 3.40.0
       '@aws-sdk/util-locate-window': 3.37.0
       '@aws-sdk/util-utf8-browser': 3.37.0
       tslib: 1.14.1
@@ -280,7 +286,7 @@ packages:
     resolution: {integrity: sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==}
     dependencies:
       '@aws-crypto/util': 2.0.0
-      '@aws-sdk/types': 3.38.0
+      '@aws-sdk/types': 3.40.0
       tslib: 1.14.1
     dev: false
 
@@ -293,7 +299,7 @@ packages:
   /@aws-crypto/util/2.0.0:
     resolution: {integrity: sha512-YDooyH83m2P5A3h6lNH7hm6mIP93sU/dtzRmXIgtO4BCB7SvtX8ysVKQAE8tVky2DQ3HHxPCjNTuUe7YoAMrNQ==}
     dependencies:
-      '@aws-sdk/types': 3.38.0
+      '@aws-sdk/types': 3.40.0
       '@aws-sdk/util-utf8-browser': 3.37.0
       tslib: 1.14.1
     dev: false
@@ -303,6 +309,14 @@ packages:
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/abort-controller/3.40.0:
+    resolution: {integrity: sha512-S7LzLvNuwuf0q7r4q7zqGzxd/W2xYsn8cpZ90MMb3ObolhbkLySrikUJujmXae8k+2/KFCOr+FVC0YLrATSUgQ==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -316,6 +330,43 @@ packages:
   /@aws-sdk/chunked-blob-reader/3.37.0:
     resolution: {integrity: sha512-uDacnFaczeO962RnVttwAQddS4rgDfI7nfeY8NV6iZkDv5uxGzHTfH4jT7WvPDM1pSMcOMDx8RJ+Tmtsd1VTsA==}
     dependencies:
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/client-cloudwatch-logs/3.41.0:
+    resolution: {integrity: sha512-RcAPUph4e5NyBsDA9wylxiF3utUNQVOKY79woffrPhv2FhTNL8lzibJ6w7XtaN2h8/pMv23ejc2bqD8oVww/8Q==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 2.0.0
+      '@aws-crypto/sha256-js': 2.0.0
+      '@aws-sdk/client-sts': 3.41.0
+      '@aws-sdk/config-resolver': 3.40.0
+      '@aws-sdk/credential-provider-node': 3.41.0
+      '@aws-sdk/fetch-http-handler': 3.40.0
+      '@aws-sdk/hash-node': 3.40.0
+      '@aws-sdk/invalid-dependency': 3.40.0
+      '@aws-sdk/middleware-content-length': 3.40.0
+      '@aws-sdk/middleware-host-header': 3.40.0
+      '@aws-sdk/middleware-logger': 3.40.0
+      '@aws-sdk/middleware-retry': 3.40.0
+      '@aws-sdk/middleware-serde': 3.40.0
+      '@aws-sdk/middleware-signing': 3.40.0
+      '@aws-sdk/middleware-stack': 3.40.0
+      '@aws-sdk/middleware-user-agent': 3.40.0
+      '@aws-sdk/node-config-provider': 3.40.0
+      '@aws-sdk/node-http-handler': 3.40.0
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/smithy-client': 3.41.0
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/url-parser': 3.40.0
+      '@aws-sdk/util-base64-browser': 3.37.0
+      '@aws-sdk/util-base64-node': 3.37.0
+      '@aws-sdk/util-body-length-browser': 3.37.0
+      '@aws-sdk/util-body-length-node': 3.37.0
+      '@aws-sdk/util-user-agent-browser': 3.40.0
+      '@aws-sdk/util-user-agent-node': 3.40.0
+      '@aws-sdk/util-utf8-browser': 3.37.0
+      '@aws-sdk/util-utf8-node': 3.37.0
       tslib: 2.3.1
     dev: false
 
@@ -445,6 +496,40 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/client-sso/3.41.0:
+    resolution: {integrity: sha512-xDvcy7wv3KdHhOpl5fZN+Ydw+dHBmsCZwMFI1ZdJVCSGO+ZKgl5KVWi1LCif6vjZP1pUuGl44oDOZz1ACqOzTg==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 2.0.0
+      '@aws-crypto/sha256-js': 2.0.0
+      '@aws-sdk/config-resolver': 3.40.0
+      '@aws-sdk/fetch-http-handler': 3.40.0
+      '@aws-sdk/hash-node': 3.40.0
+      '@aws-sdk/invalid-dependency': 3.40.0
+      '@aws-sdk/middleware-content-length': 3.40.0
+      '@aws-sdk/middleware-host-header': 3.40.0
+      '@aws-sdk/middleware-logger': 3.40.0
+      '@aws-sdk/middleware-retry': 3.40.0
+      '@aws-sdk/middleware-serde': 3.40.0
+      '@aws-sdk/middleware-stack': 3.40.0
+      '@aws-sdk/middleware-user-agent': 3.40.0
+      '@aws-sdk/node-config-provider': 3.40.0
+      '@aws-sdk/node-http-handler': 3.40.0
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/smithy-client': 3.41.0
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/url-parser': 3.40.0
+      '@aws-sdk/util-base64-browser': 3.37.0
+      '@aws-sdk/util-base64-node': 3.37.0
+      '@aws-sdk/util-body-length-browser': 3.37.0
+      '@aws-sdk/util-body-length-node': 3.37.0
+      '@aws-sdk/util-user-agent-browser': 3.40.0
+      '@aws-sdk/util-user-agent-node': 3.40.0
+      '@aws-sdk/util-utf8-browser': 3.37.0
+      '@aws-sdk/util-utf8-node': 3.37.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/client-sts/3.39.0:
     resolution: {integrity: sha512-qTPyPGq6mWeutmYOsCClO8ENZuasybGykT90C0WYP3u1ppVRLzy1eWlLddUMiyr4RbSSOpNEANV0neBgg0oQug==}
     engines: {node: '>=10.0.0'}
@@ -484,12 +569,61 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/client-sts/3.41.0:
+    resolution: {integrity: sha512-XTjmr53kMbXuVhH3B+g2jEYuhNralptsMSd4RcSHCB7BX1NmAMnMFKKTmVlmc5NizWi4x1CzExu86Q0YSqp0og==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 2.0.0
+      '@aws-crypto/sha256-js': 2.0.0
+      '@aws-sdk/config-resolver': 3.40.0
+      '@aws-sdk/credential-provider-node': 3.41.0
+      '@aws-sdk/fetch-http-handler': 3.40.0
+      '@aws-sdk/hash-node': 3.40.0
+      '@aws-sdk/invalid-dependency': 3.40.0
+      '@aws-sdk/middleware-content-length': 3.40.0
+      '@aws-sdk/middleware-host-header': 3.40.0
+      '@aws-sdk/middleware-logger': 3.40.0
+      '@aws-sdk/middleware-retry': 3.40.0
+      '@aws-sdk/middleware-sdk-sts': 3.40.0
+      '@aws-sdk/middleware-serde': 3.40.0
+      '@aws-sdk/middleware-signing': 3.40.0
+      '@aws-sdk/middleware-stack': 3.40.0
+      '@aws-sdk/middleware-user-agent': 3.40.0
+      '@aws-sdk/node-config-provider': 3.40.0
+      '@aws-sdk/node-http-handler': 3.40.0
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/smithy-client': 3.41.0
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/url-parser': 3.40.0
+      '@aws-sdk/util-base64-browser': 3.37.0
+      '@aws-sdk/util-base64-node': 3.37.0
+      '@aws-sdk/util-body-length-browser': 3.37.0
+      '@aws-sdk/util-body-length-node': 3.37.0
+      '@aws-sdk/util-user-agent-browser': 3.40.0
+      '@aws-sdk/util-user-agent-node': 3.40.0
+      '@aws-sdk/util-utf8-browser': 3.37.0
+      '@aws-sdk/util-utf8-node': 3.37.0
+      entities: 2.2.0
+      fast-xml-parser: 3.19.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/config-resolver/3.39.0:
     resolution: {integrity: sha512-NyRTl+n5DcIY8Rlx3Q9CULFuVsJtQ2uuGRo8uJ4U6QyD5VvSde9vE45dTWik703yW1IXWgK5/2P/zwEPKajvJQ==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/signature-v4': 3.39.0
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/config-resolver/3.40.0:
+    resolution: {integrity: sha512-QYy6J2k31QL6J74hPBfptnLW1kQYdN+xjwH4UQ1mv7EUhRoJN9ZY2soStJowFy4at6IIOOVWbyG5dyqvrbEovg==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/signature-v4': 3.40.0
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/util-config-provider': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -512,6 +646,15 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/credential-provider-env/3.40.0:
+    resolution: {integrity: sha512-qHZdf2vxhzZkSygjw2I4SEYFL2dMZxxYvO4QlkqQouKY81OVxs/j69oiNCjPasQzGz5jaZZKI8xEAIfkSyr1lg==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/property-provider': 3.40.0
+      '@aws-sdk/types': 3.40.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/credential-provider-imds/3.39.0:
     resolution: {integrity: sha512-D8lYSE9DGrcBTJj0IBeT0agkMAMCSXEwVV2iGlthh+/cKVo3mkVKfDqtO/Qjnxhs5+CTGnKt6fhKrY3b2lmkQA==}
     engines: {node: '>= 10.0.0'}
@@ -520,6 +663,17 @@ packages:
       '@aws-sdk/property-provider': 3.38.0
       '@aws-sdk/types': 3.38.0
       '@aws-sdk/url-parser': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/credential-provider-imds/3.40.0:
+    resolution: {integrity: sha512-Ty/wVa+BQrCFrP06AGl5S1CeLifDt68YrlYXUnkRn603SX4DvxBgVO7XFeDH58G8ziDCiqxfmVl4yjbncPPeSw==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/node-config-provider': 3.40.0
+      '@aws-sdk/property-provider': 3.40.0
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/url-parser': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -534,6 +688,21 @@ packages:
       '@aws-sdk/property-provider': 3.38.0
       '@aws-sdk/shared-ini-file-loader': 3.37.0
       '@aws-sdk/types': 3.38.0
+      '@aws-sdk/util-credentials': 3.37.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/credential-provider-ini/3.41.0:
+    resolution: {integrity: sha512-98CGEHg7Tb6HxK5ZIdbAcijvD3IpLe0ddse1xMe/Ilhjz770FS/L2UNprOP6PZTqrSfBffiMrvfThUSuUaTlIQ==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.40.0
+      '@aws-sdk/credential-provider-imds': 3.40.0
+      '@aws-sdk/credential-provider-sso': 3.41.0
+      '@aws-sdk/credential-provider-web-identity': 3.41.0
+      '@aws-sdk/property-provider': 3.40.0
+      '@aws-sdk/shared-ini-file-loader': 3.37.0
+      '@aws-sdk/types': 3.40.0
       '@aws-sdk/util-credentials': 3.37.0
       tslib: 2.3.1
     dev: false
@@ -555,6 +724,23 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/credential-provider-node/3.41.0:
+    resolution: {integrity: sha512-5FW6+wNJgyDCsbAd+mLm/1DBTDkyIYOMVzcxbr6Vi3pM4UrMFdeLdAP62edYW8usg78Xg+c6vaAoEv/M3zkS0Q==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.40.0
+      '@aws-sdk/credential-provider-imds': 3.40.0
+      '@aws-sdk/credential-provider-ini': 3.41.0
+      '@aws-sdk/credential-provider-process': 3.40.0
+      '@aws-sdk/credential-provider-sso': 3.41.0
+      '@aws-sdk/credential-provider-web-identity': 3.41.0
+      '@aws-sdk/property-provider': 3.40.0
+      '@aws-sdk/shared-ini-file-loader': 3.37.0
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/util-credentials': 3.37.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/credential-provider-process/3.38.0:
     resolution: {integrity: sha512-Dh4Xc0y1mKc1kf6sJ1OZ8zrhZTw6B6OEwQe2CNftHPnstH8Jdkrcqwro2Xg5LFmW+AXGvvd7hlPn9su5FltsZg==}
     engines: {node: '>= 10.0.0'}
@@ -562,6 +748,17 @@ packages:
       '@aws-sdk/property-provider': 3.38.0
       '@aws-sdk/shared-ini-file-loader': 3.37.0
       '@aws-sdk/types': 3.38.0
+      '@aws-sdk/util-credentials': 3.37.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/credential-provider-process/3.40.0:
+    resolution: {integrity: sha512-qsaNCDesW2GasDbzpeOA371gxugi05JWxt3EKonLbUfkGKBK7kmmL6EgLIxZuNm2/Ve4RS07PKp8yBGm4xIx9w==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/property-provider': 3.40.0
+      '@aws-sdk/shared-ini-file-loader': 3.37.0
+      '@aws-sdk/types': 3.40.0
       '@aws-sdk/util-credentials': 3.37.0
       tslib: 2.3.1
     dev: false
@@ -578,12 +775,33 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/credential-provider-sso/3.41.0:
+    resolution: {integrity: sha512-9s7SWu3RVIQ/MTcBCt35EMzxNQm3avivrbpSOKfJwxR5L+oNKPsV+gSqMlkNZGwOVJyUicIsZGcq/4ON6CjrOg==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/client-sso': 3.41.0
+      '@aws-sdk/property-provider': 3.40.0
+      '@aws-sdk/shared-ini-file-loader': 3.37.0
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/util-credentials': 3.37.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/credential-provider-web-identity/3.38.0:
     resolution: {integrity: sha512-gl/pQ4U+T16+YHweOe3K+EKZRu0NVrheokja99NYhr1QhkoVFLVRcqBj5PsRyB16rXt3yBnF0LWWEk3fSR69dQ==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/property-provider': 3.38.0
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/credential-provider-web-identity/3.41.0:
+    resolution: {integrity: sha512-VqvVoEh9C8xTXl4stKyJC5IKQhS8g1Gi5k6B9HPHLIxFRRfKxkE73DT4pMN6npnus7o0yi0MTFGQFQGYSrFO2g==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/property-provider': 3.40.0
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -664,6 +882,16 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/fetch-http-handler/3.40.0:
+    resolution: {integrity: sha512-w1HiZromoU+/bbEo89uO81l6UO/M+c2uOMnXntZqe6t3ZHUUUo3AbvhKh0QGVFqRQa+Oi0+95KqWmTHa72/9Iw==}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/querystring-builder': 3.40.0
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/util-base64-browser': 3.37.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/hash-blob-browser/3.39.0:
     resolution: {integrity: sha512-6Yut0Hrnz3kelhw3A0NGZ0J3GDb0/H47JgNuq/lOdVrHHHhurxDkHk4aaIqIPZ6SvgpbZH00bmZiY9fNhNCgEg==}
     dependencies:
@@ -682,6 +910,15 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/hash-node/3.40.0:
+    resolution: {integrity: sha512-yOXXK85DdGDktdnQtXgMdaVKii4wtMjEhJ1mrvx2A9nMFNaPhxvERkVVIUKSWlJRa9ZujOw5jWOx8d2R51/Kjg==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/util-buffer-from': 3.37.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/hash-stream-node/3.39.0:
     resolution: {integrity: sha512-3FTafLZXP0njkNGCEYKqd7Xi8sCZCtWDwfyk56cHIpLMcSfG2Cx8x+B1Uphqc6Zw9hfrlXQm+w5baMt5QqfBcA==}
     engines: {node: '>= 10.0.0'}
@@ -694,6 +931,13 @@ packages:
     resolution: {integrity: sha512-m7UNt0A/QYeS2Dzw1AOsWNJ19YRz/fHR//b/Kz3t6fyDcx/3w8bLUWYRgpM3TVZGMZPTgeaHMSKPulgsLZ33vA==}
     dependencies:
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/invalid-dependency/3.40.0:
+    resolution: {integrity: sha512-axIWtDwCBDDqEgAJipX1FB1ZNpWYXquVwKDMo+7G+ftPBZ4FEq4M1ELhXJL3hhNJ9ZmCQzv+4F6Wnt8dwuzUaQ==}
+    dependencies:
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -742,6 +986,15 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/middleware-content-length/3.40.0:
+    resolution: {integrity: sha512-sybAJb8v7I/vvL08R3+TI/XDAg9gybQTZ2treC24Ap4+jAOz4QBTHJPMKaUlEeFlMUcq4rj6/u2897ebYH6opw==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/types': 3.40.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/middleware-expect-continue/3.38.0:
     resolution: {integrity: sha512-uCmJ/qcc0L3rR0tscjEKfSQtGtI5N8wXjArGUAuz1JLVK9/AGKKeCysEbHC5ZC/JBYNfdz4TdYlUIGcP67M26g==}
     engines: {node: '>= 10.0.0'}
@@ -770,6 +1023,15 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/middleware-host-header/3.40.0:
+    resolution: {integrity: sha512-/wocR7JFOLM7/+BQM1DgAd6KCFYcdxYu1P7AhI451GlVNuYa5f89zh7p0gt3SRC6monI5lXgpL7RudhDm8fTrA==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/types': 3.40.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/middleware-location-constraint/3.38.0:
     resolution: {integrity: sha512-rd3krhnLG6xeiOEvJh9Vgx4Uej96Aqt6NG1WdNH7co+7C0O7og6ErqekXytGBebs5eoir90fArf8tsvCjV7+rg==}
     engines: {node: '>= 10.0.0'}
@@ -786,6 +1048,14 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/middleware-logger/3.40.0:
+    resolution: {integrity: sha512-19kx0Xg5ymVRKoupmhdmfTBkROcv3DZj508agpyG2YAo0abOObMlIP4Jltg0VD4PhNjGzNh0jFGJnvhjdwv4/A==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.40.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/middleware-retry/3.39.0:
     resolution: {integrity: sha512-Mh9ELBEG4eHpx2cP84+NpLd5tre90NL2HL9Ov2xOnBO7a0MeH7tb7jh21tsNBBF5AdaP7K7q0513Bw6V0VA4Zg==}
     engines: {node: '>= 10.0.0'}
@@ -793,6 +1063,17 @@ packages:
       '@aws-sdk/protocol-http': 3.38.0
       '@aws-sdk/service-error-classification': 3.38.0
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+      uuid: 8.3.2
+    dev: false
+
+  /@aws-sdk/middleware-retry/3.40.0:
+    resolution: {integrity: sha512-SMUJrukugLL7YJE5X8B2ToukxMWMPwnf7jAFr84ptycCe8bdWv8x8klQ3EtVWpyqochtNlbTi6J/tTQBniUX7A==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/service-error-classification': 3.40.0
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
       uuid: 8.3.2
     dev: false
@@ -822,11 +1103,31 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/middleware-sdk-sts/3.40.0:
+    resolution: {integrity: sha512-TcrbCvj1PkabFZiNczT3yePZtuEm2fAIw1OVnQyLcF2KW+p62Hv5YkK4MPOfx3LA/0lzjOUO1RNl2x7gzV443Q==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/middleware-signing': 3.40.0
+      '@aws-sdk/property-provider': 3.40.0
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/signature-v4': 3.40.0
+      '@aws-sdk/types': 3.40.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/middleware-serde/3.38.0:
     resolution: {integrity: sha512-vtxaBe1KkXPaqVP8pKxdur5fGi+OH6aI1OkH4yUvmxrSZtDaECuhUn+Vl2ry6KSlvyzHD4DkgiUr0pgjK1/Peg==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/middleware-serde/3.40.0:
+    resolution: {integrity: sha512-uOWfZjlAoBy6xPqp0d4ka83WNNbEVCWn9WwfqBUXThyoTdTooYSpXe5y2YzN0BJa8b+tEZTyWpgamnBpFLp47g==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -838,6 +1139,17 @@ packages:
       '@aws-sdk/protocol-http': 3.38.0
       '@aws-sdk/signature-v4': 3.39.0
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/middleware-signing/3.40.0:
+    resolution: {integrity: sha512-RqK5nPbfma0qInMvjtpVkDYY/KkFS6EKlOv3DWTdxbXJ4YuOxgKiuUromhmBUoyjFag0JO7LUWod07H+/DawoA==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/property-provider': 3.40.0
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/signature-v4': 3.40.0
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -856,12 +1168,28 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/middleware-stack/3.40.0:
+    resolution: {integrity: sha512-hby9HvESUYJxpdALX+6Dn2LPmS5jtMVurGB/+j3MWOvIcDYB4bcSXgVRvXzYnTKwbSupIdbX9zOE2ZAx2SJpUQ==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/middleware-user-agent/3.38.0:
     resolution: {integrity: sha512-ZGiGk6xlhtQULLceSXxM7KrMqfFMVkQ6yvtIn0BnJciNNnkF08FEyBq4cthvwFEO7SBGdc8XyEoi59xQP+gSkg==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/protocol-http': 3.38.0
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/middleware-user-agent/3.40.0:
+    resolution: {integrity: sha512-dzC2fxWnanetFJ1oYgil8df3N36bR1yc/OCOpbdfQNiUk1FrXiCXqH5rHNO8zCvnwJAj8GHFwpFGd9a2Qube2w==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -872,6 +1200,16 @@ packages:
       '@aws-sdk/property-provider': 3.38.0
       '@aws-sdk/shared-ini-file-loader': 3.37.0
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/node-config-provider/3.40.0:
+    resolution: {integrity: sha512-AmokjgUDECG8osoMfdRsPNweqI+L1pn4bYGk5iTLmzbBi0o4ot0U1FdX8Rf0qJZZwS4t1TXc3s8/PDVknmPxKg==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/property-provider': 3.40.0
+      '@aws-sdk/shared-ini-file-loader': 3.37.0
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -886,6 +1224,17 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/node-http-handler/3.40.0:
+    resolution: {integrity: sha512-qjda6IbxDhbYr8NHmrMurKkbjgLUkfTMVgagDErDK24Nm3Dn5VaO6J4n6c0Q4OLHlmFaRcUfZSTrOo5DAubqCw==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/abort-controller': 3.40.0
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/querystring-builder': 3.40.0
+      '@aws-sdk/types': 3.40.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/property-provider/3.38.0:
     resolution: {integrity: sha512-JLw1bw/PnA2QefaLe9CMlc/1JphIQT7Jq3JWhMz34ddZW3A45kVILwUW7klkiy/OcF/xUPs0gz45EEiUOhjj0w==}
     engines: {node: '>= 10.0.0'}
@@ -894,11 +1243,27 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/property-provider/3.40.0:
+    resolution: {integrity: sha512-Mx4lkShjsYRwW9ujHA1pcnuubrWQ4kF5/DXWNfUiXuSIO/0Lojp1qTLheyBm4vzkJIlx5umyP6NvRAUkEHSN4Q==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.40.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/protocol-http/3.38.0:
     resolution: {integrity: sha512-2z6QEJX16hvNoTZDmvrg8RIrnEv6hRCM4lELluFXE72T4FMfJpdsDWXTmQNHI8TyUcriyMjXztY62vOGNIzppg==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/protocol-http/3.40.0:
+    resolution: {integrity: sha512-f4ea7/HZkjpvGBrnRIuzc/bhrExWrgDv7eulj4htPukZGHdTqSJD3Jk8lEXWvFuX2vUKQDGhEhCDsqup7YWJQQ==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -911,11 +1276,28 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/querystring-builder/3.40.0:
+    resolution: {integrity: sha512-gO24oipnNaxJRBXB7lhLfa96vIMOd8gtMBqJTjelTjS2e1ZP1YY12CNKKTWwafSk8Ge021erZAG/YTOaXGpv+g==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/util-uri-escape': 3.37.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/querystring-parser/3.38.0:
     resolution: {integrity: sha512-rIzE+Rjmn7L0YBRrgZPzsqNu1NYSrW2v+BOdmQI8PMuhZ9T+gU6ttTTwpY/uVOmH8FeoaxWS+MRhI3FoV3eYOQ==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/querystring-parser/3.40.0:
+    resolution: {integrity: sha512-XZIyaKQIiZAM6zelCBcsLHhVDOLafi7XIOd3jy6SymGN8ajj3HqUJ/vdQ5G6ISTk18OrqgqcCOI9oNzv+nrBcA==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -940,6 +1322,11 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: false
 
+  /@aws-sdk/service-error-classification/3.40.0:
+    resolution: {integrity: sha512-c8btKmkvjXczWudXubGdbO3JgmjySBUVC/gCrZDNfwNGsG8RYJJQYYcnmt1gWjelUZsgMDl/2PIzxTlxVF91rA==}
+    engines: {node: '>= 10.0.0'}
+    dev: false
+
   /@aws-sdk/shared-ini-file-loader/3.37.0:
     resolution: {integrity: sha512-+vRBSlfa48R9KL7DpQt3dsu5/+5atjRgoCISblWo3SLpjrx41pKcjKneo7a1u0aP1Xc2oG2TfIyqTWZuOXsmEQ==}
     engines: {node: '>= 10.0.0'}
@@ -958,6 +1345,17 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/signature-v4/3.40.0:
+    resolution: {integrity: sha512-Q1GNZJRCS3W2qsRtDsX/b6EOSfMXfr6TW46N3LnLTGYZ3KAN2SOSJ1DsW59AuGpEZyRmOhJ9L/Q5U403+bZMXQ==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/is-array-buffer': 3.37.0
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/util-hex-encoding': 3.37.0
+      '@aws-sdk/util-uri-escape': 3.37.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/smithy-client/3.38.0:
     resolution: {integrity: sha512-FRYE1eNCSl5hkW8XB8XnE6YrW4TmEGq/SgJqZIsPaH0eIYoKWAAzC295go6GR/BWdqTOIgJVps5fROh/5DqLmg==}
     engines: {node: '>= 10.0.0'}
@@ -967,8 +1365,22 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/smithy-client/3.41.0:
+    resolution: {integrity: sha512-ldhS0Pf3v6yHCd//kk5DvKcdyeUkKEwxNDRanAp+ekTW68J3XcYgKaPC9sNDhVTDH1zrywTvtEz5zWHEvXjQow==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/middleware-stack': 3.40.0
+      '@aws-sdk/types': 3.40.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/types/3.38.0:
     resolution: {integrity: sha512-Opux3HLwMlWb7GIJxERsOnmbHrT2A1gsd8aF5zHapWPPH5Z0rYsgTIq64qgim896XlKlOw6/YzhD5CdyNjlQWg==}
+    engines: {node: '>= 10.0.0'}
+    dev: false
+
+  /@aws-sdk/types/3.40.0:
+    resolution: {integrity: sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==}
     engines: {node: '>= 10.0.0'}
     dev: false
 
@@ -977,6 +1389,14 @@ packages:
     dependencies:
       '@aws-sdk/querystring-parser': 3.38.0
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/url-parser/3.40.0:
+    resolution: {integrity: sha512-HwNV+HX7bHgLk5FzTOgdXANsC0SeVz5PMC4Nh+TLz2IoeQnrw4H8dsA4YNonncjern5oC5veKRjQeOoCL5SlSQ==}
+    dependencies:
+      '@aws-sdk/querystring-parser': 3.40.0
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -1019,6 +1439,13 @@ packages:
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/is-array-buffer': 3.37.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/util-config-provider/3.40.0:
+    resolution: {integrity: sha512-NjZGrA4mqhpr6gkVCAUweurP0Z9d3vFyXJCtulC0BFbpKAnKCf/crSK56NwUaNhAEMCkSuBvjRFzkbfT+HO8bA==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
       tslib: 2.3.1
     dev: false
 
@@ -1078,12 +1505,29 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@aws-sdk/util-user-agent-browser/3.40.0:
+    resolution: {integrity: sha512-C69sTI26bV2EprTv3DTXu9XP7kD9Wu4YVPBzqztOYArd2GDYw3w+jS8SEg3XRbjAKY/mOPZ2Thw4StjpZlWZiA==}
+    dependencies:
+      '@aws-sdk/types': 3.40.0
+      bowser: 2.11.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/util-user-agent-node/3.39.0:
     resolution: {integrity: sha512-uNFqhDCyOVjK6L8C1uR+AfWaslDqK180+VsWpWavtnefjstIKPbdqinu/yxaXDjL74oPbBc3wEyBpw21jeXFuA==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/node-config-provider': 3.39.0
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/util-user-agent-node/3.40.0:
+    resolution: {integrity: sha512-cjIzd0hRZFTTh7iLJD6Bciu++Em1iaM1clyG02xRl0JD5DEtDSR1zO02uu+AeM7GSLGOxIvwOkK2j8ySPAOmBA==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/node-config-provider': 3.40.0
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -1754,6 +2198,14 @@ packages:
     dependencies:
       '@cspotcode/source-map-consumer': 0.8.0
     dev: true
+
+  /@dabh/diagnostics/2.0.2:
+    resolution: {integrity: sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==}
+    dependencies:
+      colorspace: 1.1.4
+      enabled: 2.0.0
+      kuler: 2.0.0
+    dev: false
 
   /@emotion/is-prop-valid/0.8.8:
     resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
@@ -2766,6 +3218,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /async/3.2.2:
+    resolution: {integrity: sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==}
+    dev: false
+
   /asynckit/0.4.0:
     resolution: {integrity: sha1-x57Zf380y48robyXkLzDZkdLS3k=}
 
@@ -3304,8 +3760,34 @@ packages:
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  /color-string/1.6.0:
+    resolution: {integrity: sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==}
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.2
+    dev: false
+
+  /color/3.2.1:
+    resolution: {integrity: sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==}
+    dependencies:
+      color-convert: 1.9.3
+      color-string: 1.6.0
+    dev: false
+
   /colorette/1.4.0:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
+    dev: false
+
+  /colors/1.4.0:
+    resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
+    engines: {node: '>=0.1.90'}
+    dev: false
+
+  /colorspace/1.1.4:
+    resolution: {integrity: sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==}
+    dependencies:
+      color: 3.2.1
+      text-hex: 1.0.0
     dev: false
 
   /combined-stream/1.0.8:
@@ -3818,6 +4300,10 @@ packages:
   /emojis-list/2.1.0:
     resolution: {integrity: sha1-TapNnbAPmBmIDHn6RXrlsJof04k=}
     engines: {node: '>= 0.10'}
+    dev: false
+
+  /enabled/2.0.0:
+    resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
     dev: false
 
   /encoding/0.1.13:
@@ -4469,6 +4955,10 @@ packages:
       bser: 2.1.1
     dev: true
 
+  /fecha/4.2.1:
+    resolution: {integrity: sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==}
+    dev: false
+
   /file-entry-cache/6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -4542,6 +5032,10 @@ packages:
   /flatted/3.2.2:
     resolution: {integrity: sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==}
     dev: true
+
+  /fn.name/1.1.0:
+    resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
+    dev: false
 
   /foreach/2.0.5:
     resolution: {integrity: sha1-C+4AUBiusmDQo6865ljdATbsG5k=}
@@ -5042,6 +5536,10 @@ packages:
     resolution: {integrity: sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=}
     dev: true
 
+  /is-arrayish/0.3.2:
+    resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
+    dev: false
+
   /is-bigint/1.0.4:
     resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
     dependencies:
@@ -5181,7 +5679,6 @@ packages:
   /is-stream/2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
-    dev: true
 
   /is-string/1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
@@ -5920,6 +6417,10 @@ packages:
     resolution: {integrity: sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw==}
     dev: true
 
+  /kuler/2.0.0:
+    resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
+    dev: false
+
   /leven/3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -6031,6 +6532,16 @@ packages:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
     dev: true
+
+  /logform/2.3.0:
+    resolution: {integrity: sha512-graeoWUH2knKbGthMtuG1EfaSPMZFZBIrhuJHhkS5ZseFBrc7DupCzihOQAzsK/qIKPQaPJ/lFQFctILUY5ARQ==}
+    dependencies:
+      colors: 1.4.0
+      fecha: 4.2.1
+      ms: 2.1.2
+      safe-stable-stringify: 1.1.1
+      triple-beam: 1.3.0
+    dev: false
 
   /longest-streak/2.0.4:
     resolution: {integrity: sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==}
@@ -6564,6 +7075,12 @@ packages:
     resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
     dependencies:
       wrappy: 1.0.2
+
+  /one-time/1.0.0:
+    resolution: {integrity: sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==}
+    dependencies:
+      fn.name: 1.1.0
+    dev: false
 
   /onetime/5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -7353,6 +7870,15 @@ packages:
     dependencies:
       ret: 0.2.2
 
+  /safe-stable-stringify/1.1.1:
+    resolution: {integrity: sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw==}
+    dev: false
+
+  /safe-stable-stringify/2.2.0:
+    resolution: {integrity: sha512-C6AuMdYPuPV/P1leplHNu0lgc2LAElq/g3TdoksDCIVtBhr78o/CH03bt/9SKqugFbKU9CUjsNlCu0fjtQzQUw==}
+    engines: {node: '>=10'}
+    dev: false
+
   /safer-buffer/2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -7462,6 +7988,12 @@ packages:
     resolution: {integrity: sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==}
     dev: true
 
+  /simple-swizzle/0.2.2:
+    resolution: {integrity: sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=}
+    dependencies:
+      is-arrayish: 0.3.2
+    dev: false
+
   /sisteransi/1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
     dev: true
@@ -7552,6 +8084,10 @@ packages:
   /sprintf-js/1.0.3:
     resolution: {integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=}
     dev: true
+
+  /stack-trace/0.0.10:
+    resolution: {integrity: sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=}
+    dev: false
 
   /stack-utils/2.0.5:
     resolution: {integrity: sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==}
@@ -7981,6 +8517,10 @@ packages:
     engines: {node: '>=0.10'}
     dev: true
 
+  /text-hex/1.0.0:
+    resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
+    dev: false
+
   /text-table/0.2.0:
     resolution: {integrity: sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=}
     dev: true
@@ -8063,6 +8603,10 @@ packages:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
     engines: {node: '>=8'}
     dev: true
+
+  /triple-beam/1.3.0:
+    resolution: {integrity: sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==}
+    dev: false
 
   /trough/1.0.5:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
@@ -8541,6 +9085,29 @@ packages:
     dependencies:
       isexe: 2.0.0
     dev: true
+
+  /winston-transport/4.4.0:
+    resolution: {integrity: sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==}
+    engines: {node: '>= 6.4.0'}
+    dependencies:
+      readable-stream: 2.3.7
+      triple-beam: 1.3.0
+    dev: false
+
+  /winston/3.3.3:
+    resolution: {integrity: sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==}
+    engines: {node: '>= 6.4.0'}
+    dependencies:
+      '@dabh/diagnostics': 2.0.2
+      async: 3.2.2
+      is-stream: 2.0.1
+      logform: 2.3.0
+      one-time: 1.0.0
+      readable-stream: 3.6.0
+      stack-trace: 0.0.10
+      triple-beam: 1.3.0
+      winston-transport: 4.4.0
+    dev: false
 
   /word-wrap/1.2.3:
     resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,9 +98,9 @@ importers:
 
   pkg/api:
     specifiers:
-      '@aws-sdk/client-s3': ^3.29.0
-      '@aws-sdk/credential-providers': ^3.38.0
-      '@aws-sdk/s3-request-presigner': ^3.30.0
+      '@aws-sdk/client-s3': ^3.41.0
+      '@aws-sdk/credential-providers': ^3.41.0
+      '@aws-sdk/s3-request-presigner': ^3.41.0
       '@prisma/client': ^3.2.1
       '@violet/api': workspace:*
       '@violet/def': workspace:*
@@ -121,9 +121,9 @@ importers:
       uuid: ^8.3.2
       velona: ^0.7.0
     dependencies:
-      '@aws-sdk/client-s3': 3.39.0
-      '@aws-sdk/credential-providers': 3.39.0
-      '@aws-sdk/s3-request-presigner': 3.39.0
+      '@aws-sdk/client-s3': 3.41.0
+      '@aws-sdk/credential-providers': 3.41.0
+      '@aws-sdk/s3-request-presigner': 3.41.0
       '@prisma/client': 3.3.0_prisma@3.3.0
       arg: 5.0.1
       aspida: 1.7.1
@@ -153,8 +153,8 @@ importers:
 
   pkg/lambda/conv2img:
     specifiers:
-      '@aws-sdk/client-s3': ^3.40.0
-      '@aws-sdk/credential-providers': ^3.40.0
+      '@aws-sdk/client-s3': ^3.41.0
+      '@aws-sdk/credential-providers': ^3.41.0
       '@types/aws-lambda': ^8.10.84
       '@types/node': ^16.7.5
       '@violet/def': workspace:*
@@ -177,7 +177,6 @@ importers:
   pkg/lib:
     specifiers:
       '@aws-sdk/client-cloudwatch-logs': ^3.41.0
-      '@aws-sdk/client-ec2': ^3.41.0
       '@types/aws-lambda': ^8.10.84
       '@violet/def': workspace:*
       '@violet/lib': workspace:*
@@ -186,7 +185,6 @@ importers:
       winston: ^3.3.3
     dependencies:
       '@aws-sdk/client-cloudwatch-logs': 3.41.0
-      '@aws-sdk/client-ec2': 3.41.0
       ballvalve: 3.1.3
       safe-stable-stringify: 2.2.0
       winston: 3.3.3
@@ -306,14 +304,6 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@aws-sdk/abort-controller/3.38.0:
-    resolution: {integrity: sha512-99xkRHG+nHvUexyebBMhgJemEvSnQFD54dKr5DqtFFv1GEVsyTJoSDVQWY7w/EAwpqp8ms5X26NwHiJB+lll6g==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/abort-controller/3.40.0:
     resolution: {integrity: sha512-S7LzLvNuwuf0q7r4q7zqGzxd/W2xYsn8cpZ90MMb3ObolhbkLySrikUJujmXae8k+2/KFCOr+FVC0YLrATSUgQ==}
     engines: {node: '>= 10.0.0'}
@@ -372,43 +362,6 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/client-cognito-identity/3.39.0:
-    resolution: {integrity: sha512-WJc6e8HPWDmiq0Lx+fHTApLxkeT1c2C8LI7BTbefQNtklvkC6mjUNpZS/0dp4ZAODQFJW222KZpEY6l8V32gHA==}
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      '@aws-crypto/sha256-browser': 2.0.0
-      '@aws-crypto/sha256-js': 2.0.0
-      '@aws-sdk/client-sts': 3.39.0
-      '@aws-sdk/config-resolver': 3.39.0
-      '@aws-sdk/credential-provider-node': 3.39.0
-      '@aws-sdk/fetch-http-handler': 3.38.0
-      '@aws-sdk/hash-node': 3.38.0
-      '@aws-sdk/invalid-dependency': 3.38.0
-      '@aws-sdk/middleware-content-length': 3.38.0
-      '@aws-sdk/middleware-host-header': 3.38.0
-      '@aws-sdk/middleware-logger': 3.38.0
-      '@aws-sdk/middleware-retry': 3.39.0
-      '@aws-sdk/middleware-serde': 3.38.0
-      '@aws-sdk/middleware-signing': 3.39.0
-      '@aws-sdk/middleware-stack': 3.38.0
-      '@aws-sdk/middleware-user-agent': 3.38.0
-      '@aws-sdk/node-config-provider': 3.39.0
-      '@aws-sdk/node-http-handler': 3.38.0
-      '@aws-sdk/protocol-http': 3.38.0
-      '@aws-sdk/smithy-client': 3.38.0
-      '@aws-sdk/types': 3.38.0
-      '@aws-sdk/url-parser': 3.38.0
-      '@aws-sdk/util-base64-browser': 3.37.0
-      '@aws-sdk/util-base64-node': 3.37.0
-      '@aws-sdk/util-body-length-browser': 3.37.0
-      '@aws-sdk/util-body-length-node': 3.37.0
-      '@aws-sdk/util-user-agent-browser': 3.38.0
-      '@aws-sdk/util-user-agent-node': 3.39.0
-      '@aws-sdk/util-utf8-browser': 3.37.0
-      '@aws-sdk/util-utf8-node': 3.37.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/client-cognito-identity/3.41.0:
     resolution: {integrity: sha512-rmlVJi75hLTeUoflafkyINSGD58du7XxxICbT2LGUkkqptfp/y0MViX8kgbymBMs7PdNcyDvevUCzGW6Zdhu0A==}
     engines: {node: '>=10.0.0'}
@@ -444,103 +397,6 @@ packages:
       '@aws-sdk/util-utf8-browser': 3.37.0
       '@aws-sdk/util-utf8-node': 3.37.0
       tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/client-ec2/3.41.0:
-    resolution: {integrity: sha512-IbThcHKAjNLPIaym6Z4EDnnJOTahQ7Y+Vu9OG+fLsCAeA4z6Py322c0SE2CcGnkliOm61LrZikhFdhSOAexOEw==}
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      '@aws-crypto/sha256-browser': 2.0.0
-      '@aws-crypto/sha256-js': 2.0.0
-      '@aws-sdk/client-sts': 3.41.0
-      '@aws-sdk/config-resolver': 3.40.0
-      '@aws-sdk/credential-provider-node': 3.41.0
-      '@aws-sdk/fetch-http-handler': 3.40.0
-      '@aws-sdk/hash-node': 3.40.0
-      '@aws-sdk/invalid-dependency': 3.40.0
-      '@aws-sdk/middleware-content-length': 3.40.0
-      '@aws-sdk/middleware-host-header': 3.40.0
-      '@aws-sdk/middleware-logger': 3.40.0
-      '@aws-sdk/middleware-retry': 3.40.0
-      '@aws-sdk/middleware-sdk-ec2': 3.40.0
-      '@aws-sdk/middleware-serde': 3.40.0
-      '@aws-sdk/middleware-signing': 3.40.0
-      '@aws-sdk/middleware-stack': 3.40.0
-      '@aws-sdk/middleware-user-agent': 3.40.0
-      '@aws-sdk/node-config-provider': 3.40.0
-      '@aws-sdk/node-http-handler': 3.40.0
-      '@aws-sdk/protocol-http': 3.40.0
-      '@aws-sdk/smithy-client': 3.41.0
-      '@aws-sdk/types': 3.40.0
-      '@aws-sdk/url-parser': 3.40.0
-      '@aws-sdk/util-base64-browser': 3.37.0
-      '@aws-sdk/util-base64-node': 3.37.0
-      '@aws-sdk/util-body-length-browser': 3.37.0
-      '@aws-sdk/util-body-length-node': 3.37.0
-      '@aws-sdk/util-user-agent-browser': 3.40.0
-      '@aws-sdk/util-user-agent-node': 3.40.0
-      '@aws-sdk/util-utf8-browser': 3.37.0
-      '@aws-sdk/util-utf8-node': 3.37.0
-      '@aws-sdk/util-waiter': 3.40.0
-      entities: 2.2.0
-      fast-xml-parser: 3.19.0
-      tslib: 2.3.1
-      uuid: 8.3.2
-    dev: false
-
-  /@aws-sdk/client-s3/3.39.0:
-    resolution: {integrity: sha512-FQNJ9IWhpZtd9+if2T2vVHdyqFFytX2l26R4RuBzNLO8XKR0CS++gksbg8X7G5e0ETmltofHoqvay6NvddhZVA==}
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      '@aws-crypto/sha256-browser': 2.0.0
-      '@aws-crypto/sha256-js': 2.0.0
-      '@aws-sdk/client-sts': 3.39.0
-      '@aws-sdk/config-resolver': 3.39.0
-      '@aws-sdk/credential-provider-node': 3.39.0
-      '@aws-sdk/eventstream-serde-browser': 3.39.0
-      '@aws-sdk/eventstream-serde-config-resolver': 3.38.0
-      '@aws-sdk/eventstream-serde-node': 3.39.0
-      '@aws-sdk/fetch-http-handler': 3.38.0
-      '@aws-sdk/hash-blob-browser': 3.39.0
-      '@aws-sdk/hash-node': 3.38.0
-      '@aws-sdk/hash-stream-node': 3.39.0
-      '@aws-sdk/invalid-dependency': 3.38.0
-      '@aws-sdk/md5-js': 3.38.0
-      '@aws-sdk/middleware-apply-body-checksum': 3.38.0
-      '@aws-sdk/middleware-bucket-endpoint': 3.39.0
-      '@aws-sdk/middleware-content-length': 3.38.0
-      '@aws-sdk/middleware-expect-continue': 3.38.0
-      '@aws-sdk/middleware-host-header': 3.38.0
-      '@aws-sdk/middleware-location-constraint': 3.38.0
-      '@aws-sdk/middleware-logger': 3.38.0
-      '@aws-sdk/middleware-retry': 3.39.0
-      '@aws-sdk/middleware-sdk-s3': 3.39.0
-      '@aws-sdk/middleware-serde': 3.38.0
-      '@aws-sdk/middleware-signing': 3.39.0
-      '@aws-sdk/middleware-ssec': 3.38.0
-      '@aws-sdk/middleware-stack': 3.38.0
-      '@aws-sdk/middleware-user-agent': 3.38.0
-      '@aws-sdk/node-config-provider': 3.39.0
-      '@aws-sdk/node-http-handler': 3.38.0
-      '@aws-sdk/protocol-http': 3.38.0
-      '@aws-sdk/smithy-client': 3.38.0
-      '@aws-sdk/types': 3.38.0
-      '@aws-sdk/url-parser': 3.38.0
-      '@aws-sdk/util-base64-browser': 3.37.0
-      '@aws-sdk/util-base64-node': 3.37.0
-      '@aws-sdk/util-body-length-browser': 3.37.0
-      '@aws-sdk/util-body-length-node': 3.37.0
-      '@aws-sdk/util-user-agent-browser': 3.38.0
-      '@aws-sdk/util-user-agent-node': 3.39.0
-      '@aws-sdk/util-utf8-browser': 3.37.0
-      '@aws-sdk/util-utf8-node': 3.37.0
-      '@aws-sdk/util-waiter': 3.38.0
-      '@aws-sdk/xml-builder': 3.37.0
-      entities: 2.2.0
-      fast-xml-parser: 3.19.0
-      tslib: 2.3.1
-    transitivePeerDependencies:
-      - '@aws-sdk/signature-v4-crt'
     dev: false
 
   /@aws-sdk/client-s3/3.41.0:
@@ -598,40 +454,6 @@ packages:
       - '@aws-sdk/signature-v4-crt'
     dev: false
 
-  /@aws-sdk/client-sso/3.39.0:
-    resolution: {integrity: sha512-HVYp893RQIxmHzJVzb2h7IVn8uRPSDuLtsM9edcaAQs5aMlfICH8aW+p9em9keGZA9EcNNYOCZN7HspFV9LG+A==}
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      '@aws-crypto/sha256-browser': 2.0.0
-      '@aws-crypto/sha256-js': 2.0.0
-      '@aws-sdk/config-resolver': 3.39.0
-      '@aws-sdk/fetch-http-handler': 3.38.0
-      '@aws-sdk/hash-node': 3.38.0
-      '@aws-sdk/invalid-dependency': 3.38.0
-      '@aws-sdk/middleware-content-length': 3.38.0
-      '@aws-sdk/middleware-host-header': 3.38.0
-      '@aws-sdk/middleware-logger': 3.38.0
-      '@aws-sdk/middleware-retry': 3.39.0
-      '@aws-sdk/middleware-serde': 3.38.0
-      '@aws-sdk/middleware-stack': 3.38.0
-      '@aws-sdk/middleware-user-agent': 3.38.0
-      '@aws-sdk/node-config-provider': 3.39.0
-      '@aws-sdk/node-http-handler': 3.38.0
-      '@aws-sdk/protocol-http': 3.38.0
-      '@aws-sdk/smithy-client': 3.38.0
-      '@aws-sdk/types': 3.38.0
-      '@aws-sdk/url-parser': 3.38.0
-      '@aws-sdk/util-base64-browser': 3.37.0
-      '@aws-sdk/util-base64-node': 3.37.0
-      '@aws-sdk/util-body-length-browser': 3.37.0
-      '@aws-sdk/util-body-length-node': 3.37.0
-      '@aws-sdk/util-user-agent-browser': 3.38.0
-      '@aws-sdk/util-user-agent-node': 3.39.0
-      '@aws-sdk/util-utf8-browser': 3.37.0
-      '@aws-sdk/util-utf8-node': 3.37.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/client-sso/3.41.0:
     resolution: {integrity: sha512-xDvcy7wv3KdHhOpl5fZN+Ydw+dHBmsCZwMFI1ZdJVCSGO+ZKgl5KVWi1LCif6vjZP1pUuGl44oDOZz1ACqOzTg==}
     engines: {node: '>=10.0.0'}
@@ -663,45 +485,6 @@ packages:
       '@aws-sdk/util-user-agent-node': 3.40.0
       '@aws-sdk/util-utf8-browser': 3.37.0
       '@aws-sdk/util-utf8-node': 3.37.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/client-sts/3.39.0:
-    resolution: {integrity: sha512-qTPyPGq6mWeutmYOsCClO8ENZuasybGykT90C0WYP3u1ppVRLzy1eWlLddUMiyr4RbSSOpNEANV0neBgg0oQug==}
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      '@aws-crypto/sha256-browser': 2.0.0
-      '@aws-crypto/sha256-js': 2.0.0
-      '@aws-sdk/config-resolver': 3.39.0
-      '@aws-sdk/credential-provider-node': 3.39.0
-      '@aws-sdk/fetch-http-handler': 3.38.0
-      '@aws-sdk/hash-node': 3.38.0
-      '@aws-sdk/invalid-dependency': 3.38.0
-      '@aws-sdk/middleware-content-length': 3.38.0
-      '@aws-sdk/middleware-host-header': 3.38.0
-      '@aws-sdk/middleware-logger': 3.38.0
-      '@aws-sdk/middleware-retry': 3.39.0
-      '@aws-sdk/middleware-sdk-sts': 3.39.0
-      '@aws-sdk/middleware-serde': 3.38.0
-      '@aws-sdk/middleware-signing': 3.39.0
-      '@aws-sdk/middleware-stack': 3.38.0
-      '@aws-sdk/middleware-user-agent': 3.38.0
-      '@aws-sdk/node-config-provider': 3.39.0
-      '@aws-sdk/node-http-handler': 3.38.0
-      '@aws-sdk/protocol-http': 3.38.0
-      '@aws-sdk/smithy-client': 3.38.0
-      '@aws-sdk/types': 3.38.0
-      '@aws-sdk/url-parser': 3.38.0
-      '@aws-sdk/util-base64-browser': 3.37.0
-      '@aws-sdk/util-base64-node': 3.37.0
-      '@aws-sdk/util-body-length-browser': 3.37.0
-      '@aws-sdk/util-body-length-node': 3.37.0
-      '@aws-sdk/util-user-agent-browser': 3.38.0
-      '@aws-sdk/util-user-agent-node': 3.39.0
-      '@aws-sdk/util-utf8-browser': 3.37.0
-      '@aws-sdk/util-utf8-node': 3.37.0
-      entities: 2.2.0
-      fast-xml-parser: 3.19.0
       tslib: 2.3.1
     dev: false
 
@@ -744,15 +527,6 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/config-resolver/3.39.0:
-    resolution: {integrity: sha512-NyRTl+n5DcIY8Rlx3Q9CULFuVsJtQ2uuGRo8uJ4U6QyD5VvSde9vE45dTWik703yW1IXWgK5/2P/zwEPKajvJQ==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/signature-v4': 3.39.0
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/config-resolver/3.40.0:
     resolution: {integrity: sha512-QYy6J2k31QL6J74hPBfptnLW1kQYdN+xjwH4UQ1mv7EUhRoJN9ZY2soStJowFy4at6IIOOVWbyG5dyqvrbEovg==}
     engines: {node: '>= 10.0.0'}
@@ -760,16 +534,6 @@ packages:
       '@aws-sdk/signature-v4': 3.40.0
       '@aws-sdk/types': 3.40.0
       '@aws-sdk/util-config-provider': 3.40.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/credential-provider-cognito-identity/3.39.0:
-    resolution: {integrity: sha512-sceXqILjV5hBLgvxbqPgxAgafeS0sVrVTFUpvV1Lo1BP5H80YPiZZd+Hhf6B2KCjr6KG/4ib1/n5USAQJ/mOfA==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/client-cognito-identity': 3.39.0
-      '@aws-sdk/property-provider': 3.38.0
-      '@aws-sdk/types': 3.38.0
       tslib: 2.3.1
     dev: false
 
@@ -783,32 +547,12 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/credential-provider-env/3.38.0:
-    resolution: {integrity: sha512-XrPwlT/txzBttkU4B11igfcwcgQyG70WOvNGtjD8C4r9dNJgIH4eDcIwPeGpxC6iz5ulb9Y4M50nLgovJhtxvg==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/property-provider': 3.38.0
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/credential-provider-env/3.40.0:
     resolution: {integrity: sha512-qHZdf2vxhzZkSygjw2I4SEYFL2dMZxxYvO4QlkqQouKY81OVxs/j69oiNCjPasQzGz5jaZZKI8xEAIfkSyr1lg==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/property-provider': 3.40.0
       '@aws-sdk/types': 3.40.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/credential-provider-imds/3.39.0:
-    resolution: {integrity: sha512-D8lYSE9DGrcBTJj0IBeT0agkMAMCSXEwVV2iGlthh+/cKVo3mkVKfDqtO/Qjnxhs5+CTGnKt6fhKrY3b2lmkQA==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/node-config-provider': 3.39.0
-      '@aws-sdk/property-provider': 3.38.0
-      '@aws-sdk/types': 3.38.0
-      '@aws-sdk/url-parser': 3.38.0
       tslib: 2.3.1
     dev: false
 
@@ -823,21 +567,6 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/credential-provider-ini/3.39.0:
-    resolution: {integrity: sha512-424COz8Kbu6SQjOsmABXr+NoVyVb9vRGApnCmiJxGpEc2C8J5ak2cUhZY2enlkLV/Ij+DzfP3oDgR7SFtGBE3Q==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.38.0
-      '@aws-sdk/credential-provider-imds': 3.39.0
-      '@aws-sdk/credential-provider-sso': 3.39.0
-      '@aws-sdk/credential-provider-web-identity': 3.38.0
-      '@aws-sdk/property-provider': 3.38.0
-      '@aws-sdk/shared-ini-file-loader': 3.37.0
-      '@aws-sdk/types': 3.38.0
-      '@aws-sdk/util-credentials': 3.37.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/credential-provider-ini/3.41.0:
     resolution: {integrity: sha512-98CGEHg7Tb6HxK5ZIdbAcijvD3IpLe0ddse1xMe/Ilhjz770FS/L2UNprOP6PZTqrSfBffiMrvfThUSuUaTlIQ==}
     engines: {node: '>= 10.0.0'}
@@ -849,23 +578,6 @@ packages:
       '@aws-sdk/property-provider': 3.40.0
       '@aws-sdk/shared-ini-file-loader': 3.37.0
       '@aws-sdk/types': 3.40.0
-      '@aws-sdk/util-credentials': 3.37.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/credential-provider-node/3.39.0:
-    resolution: {integrity: sha512-JedASvuCiaJwbmKIXHoC3ukQBU6Sw164GCzNprZv5+LTrBsuLTAagl2/1oTZZRSnhDmVxKI79N48lpXq0l9egg==}
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.38.0
-      '@aws-sdk/credential-provider-imds': 3.39.0
-      '@aws-sdk/credential-provider-ini': 3.39.0
-      '@aws-sdk/credential-provider-process': 3.38.0
-      '@aws-sdk/credential-provider-sso': 3.39.0
-      '@aws-sdk/credential-provider-web-identity': 3.38.0
-      '@aws-sdk/property-provider': 3.38.0
-      '@aws-sdk/shared-ini-file-loader': 3.37.0
-      '@aws-sdk/types': 3.38.0
       '@aws-sdk/util-credentials': 3.37.0
       tslib: 2.3.1
     dev: false
@@ -887,17 +599,6 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/credential-provider-process/3.38.0:
-    resolution: {integrity: sha512-Dh4Xc0y1mKc1kf6sJ1OZ8zrhZTw6B6OEwQe2CNftHPnstH8Jdkrcqwro2Xg5LFmW+AXGvvd7hlPn9su5FltsZg==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/property-provider': 3.38.0
-      '@aws-sdk/shared-ini-file-loader': 3.37.0
-      '@aws-sdk/types': 3.38.0
-      '@aws-sdk/util-credentials': 3.37.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/credential-provider-process/3.40.0:
     resolution: {integrity: sha512-qsaNCDesW2GasDbzpeOA371gxugi05JWxt3EKonLbUfkGKBK7kmmL6EgLIxZuNm2/Ve4RS07PKp8yBGm4xIx9w==}
     engines: {node: '>= 10.0.0'}
@@ -905,18 +606,6 @@ packages:
       '@aws-sdk/property-provider': 3.40.0
       '@aws-sdk/shared-ini-file-loader': 3.37.0
       '@aws-sdk/types': 3.40.0
-      '@aws-sdk/util-credentials': 3.37.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/credential-provider-sso/3.39.0:
-    resolution: {integrity: sha512-A98ZzbS+lhQnepmf8DKTIXrr+xwe07Mpao0vEKjxnxE4AzRMMcjUxti8D7BKfLE4EFMXU+M6A6M5BlVM+kLROQ==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/client-sso': 3.39.0
-      '@aws-sdk/property-provider': 3.38.0
-      '@aws-sdk/shared-ini-file-loader': 3.37.0
-      '@aws-sdk/types': 3.38.0
       '@aws-sdk/util-credentials': 3.37.0
       tslib: 2.3.1
     dev: false
@@ -933,42 +622,12 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/credential-provider-web-identity/3.38.0:
-    resolution: {integrity: sha512-gl/pQ4U+T16+YHweOe3K+EKZRu0NVrheokja99NYhr1QhkoVFLVRcqBj5PsRyB16rXt3yBnF0LWWEk3fSR69dQ==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/property-provider': 3.38.0
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/credential-provider-web-identity/3.41.0:
     resolution: {integrity: sha512-VqvVoEh9C8xTXl4stKyJC5IKQhS8g1Gi5k6B9HPHLIxFRRfKxkE73DT4pMN6npnus7o0yi0MTFGQFQGYSrFO2g==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/property-provider': 3.40.0
       '@aws-sdk/types': 3.40.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/credential-providers/3.39.0:
-    resolution: {integrity: sha512-+23tz3kpwwtM45c4ZDcq2C1e9F1VRETugUs/TOBmROPHUnlauDUryVMIJjEZZh9CeXGIznvHNYhPdCRh4YhxIA==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/client-cognito-identity': 3.39.0
-      '@aws-sdk/client-sso': 3.39.0
-      '@aws-sdk/client-sts': 3.39.0
-      '@aws-sdk/credential-provider-cognito-identity': 3.39.0
-      '@aws-sdk/credential-provider-env': 3.38.0
-      '@aws-sdk/credential-provider-imds': 3.39.0
-      '@aws-sdk/credential-provider-ini': 3.39.0
-      '@aws-sdk/credential-provider-process': 3.38.0
-      '@aws-sdk/credential-provider-sso': 3.39.0
-      '@aws-sdk/credential-provider-web-identity': 3.38.0
-      '@aws-sdk/property-provider': 3.38.0
-      '@aws-sdk/shared-ini-file-loader': 3.37.0
-      '@aws-sdk/types': 3.38.0
-      '@aws-sdk/util-credentials': 3.37.0
       tslib: 2.3.1
     dev: false
 
@@ -993,31 +652,12 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/eventstream-marshaller/3.39.0:
-    resolution: {integrity: sha512-L6sSixpE3O9YCfBT2UoCM/p5zgMhVJcd5Ih9dkTDGD1Fi3TFu21tz9GNUrk6oY0J32S0VDkMdLMXnDbbghf9lQ==}
-    dependencies:
-      '@aws-crypto/crc32': 2.0.0
-      '@aws-sdk/types': 3.38.0
-      '@aws-sdk/util-hex-encoding': 3.37.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/eventstream-marshaller/3.40.0:
     resolution: {integrity: sha512-zHGchfkG3B9M8OOKRpByeS5g1/15YQ0+QQHwxQRtm/CPtKBAIAsCZRQaCNBLu9uQMtBBKj5JsDUcjirhGeSvIg==}
     dependencies:
       '@aws-crypto/crc32': 2.0.0
       '@aws-sdk/types': 3.40.0
       '@aws-sdk/util-hex-encoding': 3.37.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/eventstream-serde-browser/3.39.0:
-    resolution: {integrity: sha512-zSnMqLwpEbEsOvapszclJPcIYBhJS99Ux8ebnFlvOkBnLMy5x3krpUwoZtQfYsqUtNvAnVKKLWS3sPTiql8+eA==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/eventstream-marshaller': 3.39.0
-      '@aws-sdk/eventstream-serde-universal': 3.39.0
-      '@aws-sdk/types': 3.38.0
       tslib: 2.3.1
     dev: false
 
@@ -1031,29 +671,11 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/eventstream-serde-config-resolver/3.38.0:
-    resolution: {integrity: sha512-IuA17V0xktmSDGPtKjyrTqo7ysdWkcHrC9DjeKO+tWjvIgoG8pJ1i/BtSU7CKfdB9GygN3FP+NwE+YlyiriDhQ==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/eventstream-serde-config-resolver/3.40.0:
     resolution: {integrity: sha512-GgGiJBsQ1/SBTpRM/wCdFBCMo1Nybvy46bNVkH1ujCdp8UTLc5PozzNpH+15V2IQbc9sPDYffMab6HSFjDp5vw==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/types': 3.40.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/eventstream-serde-node/3.39.0:
-    resolution: {integrity: sha512-HHMGwmXFDJ5p4/8OnIjlVH1Z4rsgWeiOZmVXmCKMGxmt8CfTo1bhXRVhZ4I9wVHQa8/TqQqQEqtXfnGSmkOP/Q==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/eventstream-marshaller': 3.39.0
-      '@aws-sdk/eventstream-serde-universal': 3.39.0
-      '@aws-sdk/types': 3.38.0
       tslib: 2.3.1
     dev: false
 
@@ -1067,31 +689,12 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/eventstream-serde-universal/3.39.0:
-    resolution: {integrity: sha512-J6O/mspnMZq6lGl+lNsLHTZ4sqEid7eN+1NxcnFhMdZlOaPh9H9tNVQlCeSbQn6PfAR+4cdumkyKXVXt+9RDTA==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/eventstream-marshaller': 3.39.0
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/eventstream-serde-universal/3.40.0:
     resolution: {integrity: sha512-rkHwVMyZJMhp9iBixkuaAGQNer/DPxZ9kxDDtE+LuAMhepTYQ8c4lUW0QQhYbNMWf48QKD1G4FV3JXIj9JfP9A==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/eventstream-marshaller': 3.40.0
       '@aws-sdk/types': 3.40.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/fetch-http-handler/3.38.0:
-    resolution: {integrity: sha512-gmqudofPX4cdCNOtrI/DVjUO5vbNxH3dT0WwsYtHDG95KlT+cpVE1eeE4f1rL2QpCgC5zuN1lxqhbh+vktrGXw==}
-    dependencies:
-      '@aws-sdk/protocol-http': 3.38.0
-      '@aws-sdk/querystring-builder': 3.38.0
-      '@aws-sdk/types': 3.38.0
-      '@aws-sdk/util-base64-browser': 3.37.0
       tslib: 2.3.1
     dev: false
 
@@ -1105,30 +708,12 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/hash-blob-browser/3.39.0:
-    resolution: {integrity: sha512-6Yut0Hrnz3kelhw3A0NGZ0J3GDb0/H47JgNuq/lOdVrHHHhurxDkHk4aaIqIPZ6SvgpbZH00bmZiY9fNhNCgEg==}
-    dependencies:
-      '@aws-sdk/chunked-blob-reader': 3.37.0
-      '@aws-sdk/chunked-blob-reader-native': 3.37.0
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/hash-blob-browser/3.40.0:
     resolution: {integrity: sha512-l8xyprVVKKH+720VrQ677X6VkvHttDXB4MxkMuxhSvwYBQwsRzP2Wppo7xIAtWGoS+oqlLmD4LCbHdhFRcN5yA==}
     dependencies:
       '@aws-sdk/chunked-blob-reader': 3.37.0
       '@aws-sdk/chunked-blob-reader-native': 3.37.0
       '@aws-sdk/types': 3.40.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/hash-node/3.38.0:
-    resolution: {integrity: sha512-IRxBx2KDsu/lK0/d411UzxvR1FctZ9vz5L5UnULA0SVGPti3kxCQOSmk9eFdvxRZgp0+AByDCKmAZJrcYKNDqg==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.38.0
-      '@aws-sdk/util-buffer-from': 3.37.0
       tslib: 2.3.1
     dev: false
 
@@ -1141,26 +726,11 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/hash-stream-node/3.39.0:
-    resolution: {integrity: sha512-3FTafLZXP0njkNGCEYKqd7Xi8sCZCtWDwfyk56cHIpLMcSfG2Cx8x+B1Uphqc6Zw9hfrlXQm+w5baMt5QqfBcA==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/hash-stream-node/3.40.0:
     resolution: {integrity: sha512-4yvRwODMGYtj6qrt+fyydV5MwVwPPoyoeqDoXdLo9x75vRY71DT1pMRt8PDOoY/ZwWbIdEt4+V7x0sLt2uy9WA==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/types': 3.40.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/invalid-dependency/3.38.0:
-    resolution: {integrity: sha512-m7UNt0A/QYeS2Dzw1AOsWNJ19YRz/fHR//b/Kz3t6fyDcx/3w8bLUWYRgpM3TVZGMZPTgeaHMSKPulgsLZ33vA==}
-    dependencies:
-      '@aws-sdk/types': 3.38.0
       tslib: 2.3.1
     dev: false
 
@@ -1178,31 +748,12 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/md5-js/3.38.0:
-    resolution: {integrity: sha512-5CWLDLkmpB2Lez6DCZK8JyCZSRe+ih+jdmy1jKTI4qo/qC3zRzUft6h2BxN3sKbEKBZb34Rj2p9JrYGsh6AeyA==}
-    dependencies:
-      '@aws-sdk/types': 3.38.0
-      '@aws-sdk/util-utf8-browser': 3.37.0
-      '@aws-sdk/util-utf8-node': 3.37.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/md5-js/3.40.0:
     resolution: {integrity: sha512-P1tzEljMD/MkjSc00TkVBYvfaVv/7S+04YEwE7tpu/jtxWxMHnk3CMKqq/F2iMhY83DRoqoYy+YqnaF4Bzr1uA==}
     dependencies:
       '@aws-sdk/types': 3.40.0
       '@aws-sdk/util-utf8-browser': 3.37.0
       '@aws-sdk/util-utf8-node': 3.37.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/middleware-apply-body-checksum/3.38.0:
-    resolution: {integrity: sha512-aQ8ndDFZj0PK6pS2FuUQAA9DvuOt4kfX4VLr9Fl74swyFqnrSvm/oUBTpUMguSpys6CD/vgJiY0pDaQkHKPxTA==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/is-array-buffer': 3.37.0
-      '@aws-sdk/protocol-http': 3.38.0
-      '@aws-sdk/types': 3.38.0
       tslib: 2.3.1
     dev: false
 
@@ -1213,16 +764,6 @@ packages:
       '@aws-sdk/is-array-buffer': 3.37.0
       '@aws-sdk/protocol-http': 3.40.0
       '@aws-sdk/types': 3.40.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/middleware-bucket-endpoint/3.39.0:
-    resolution: {integrity: sha512-Iv8wIsgE7lV+Ln3TFpZaJKmzmDkQPf30afNKuu063Gfa5PgSvDWtCjnJn6TXSGo4ND1NLPihCq8gshlc3M8F+A==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/protocol-http': 3.38.0
-      '@aws-sdk/types': 3.38.0
-      '@aws-sdk/util-arn-parser': 3.37.0
       tslib: 2.3.1
     dev: false
 
@@ -1237,31 +778,12 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/middleware-content-length/3.38.0:
-    resolution: {integrity: sha512-deFrPlQaFKD9VIysI/EUeOziUE+5mfTfv6y8CMZTha8GpMeyxyajf+S+S//z8ZeC8Bg8HQSD9jEOaF2qrsH+FQ==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/protocol-http': 3.38.0
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/middleware-content-length/3.40.0:
     resolution: {integrity: sha512-sybAJb8v7I/vvL08R3+TI/XDAg9gybQTZ2treC24Ap4+jAOz4QBTHJPMKaUlEeFlMUcq4rj6/u2897ebYH6opw==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/protocol-http': 3.40.0
       '@aws-sdk/types': 3.40.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/middleware-expect-continue/3.38.0:
-    resolution: {integrity: sha512-uCmJ/qcc0L3rR0tscjEKfSQtGtI5N8wXjArGUAuz1JLVK9/AGKKeCysEbHC5ZC/JBYNfdz4TdYlUIGcP67M26g==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/middleware-header-default': 3.38.0
-      '@aws-sdk/protocol-http': 3.38.0
-      '@aws-sdk/types': 3.38.0
       tslib: 2.3.1
     dev: false
 
@@ -1275,30 +797,12 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/middleware-header-default/3.38.0:
-    resolution: {integrity: sha512-PlKarclVCf4olPUrjuxdxv6uS9WSGGV0dmyyn5Ep32iGwx9CXMkrSxql7lPb/7RE/ZHNCCJo+EpARs18wBsGXQ==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/protocol-http': 3.38.0
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/middleware-header-default/3.40.0:
     resolution: {integrity: sha512-eXQ13x/AivPZKoG8/akp9g5xdNHuKftl83GMuk9K6tt4+eAa22TdxiFu4R0UVlKAvo2feqxFrNs5DhhhBeAQWA==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/protocol-http': 3.40.0
       '@aws-sdk/types': 3.40.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/middleware-host-header/3.38.0:
-    resolution: {integrity: sha512-Mu9InSNhhobO/Zu/uFd+Ss7Fj6rl20ylXE6Uxkj4oUEAb1FoSsaX9vlpefwdX7xiDWRipOv2clFbCcnhgqRcCg==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/protocol-http': 3.38.0
-      '@aws-sdk/types': 3.38.0
       tslib: 2.3.1
     dev: false
 
@@ -1311,27 +815,11 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/middleware-location-constraint/3.38.0:
-    resolution: {integrity: sha512-rd3krhnLG6xeiOEvJh9Vgx4Uej96Aqt6NG1WdNH7co+7C0O7og6ErqekXytGBebs5eoir90fArf8tsvCjV7+rg==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/middleware-location-constraint/3.40.0:
     resolution: {integrity: sha512-9XaVPYsDQVJbWJH96sNdv4HHY3j1raman+lYxMu4528Awp0OdWUeSsGRYRN+CnRPlkHnfNw4m6SKdWYHxdjshw==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/types': 3.40.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/middleware-logger/3.38.0:
-    resolution: {integrity: sha512-j8vlFwCg5he0r05yT83pYQBnXy91O9VscrEchqA+1BIX50JE2y1QCtQQwor9cBiKkU0BPCWuDC0L9uZGbBmVMg==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.38.0
       tslib: 2.3.1
     dev: false
 
@@ -1343,17 +831,6 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/middleware-retry/3.39.0:
-    resolution: {integrity: sha512-Mh9ELBEG4eHpx2cP84+NpLd5tre90NL2HL9Ov2xOnBO7a0MeH7tb7jh21tsNBBF5AdaP7K7q0513Bw6V0VA4Zg==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/protocol-http': 3.38.0
-      '@aws-sdk/service-error-classification': 3.38.0
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-      uuid: 8.3.2
-    dev: false
-
   /@aws-sdk/middleware-retry/3.40.0:
     resolution: {integrity: sha512-SMUJrukugLL7YJE5X8B2ToukxMWMPwnf7jAFr84ptycCe8bdWv8x8klQ3EtVWpyqochtNlbTi6J/tTQBniUX7A==}
     engines: {node: '>= 10.0.0'}
@@ -1363,31 +840,6 @@ packages:
       '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
       uuid: 8.3.2
-    dev: false
-
-  /@aws-sdk/middleware-sdk-ec2/3.40.0:
-    resolution: {integrity: sha512-f6AXG5LlADhyyR1yirXfSKWOqu2uWAPHy0lNUZBnOBsYHbBiqVuQI9oyo1N9xtEHCmTFePYgfsdOdct9YuvAWw==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/protocol-http': 3.40.0
-      '@aws-sdk/signature-v4': 3.40.0
-      '@aws-sdk/types': 3.40.0
-      '@aws-sdk/util-format-url': 3.40.0
-      '@aws-sdk/util-uri-escape': 3.37.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/middleware-sdk-s3/3.39.0:
-    resolution: {integrity: sha512-3vbMrUAqACIMJ/mORrV6AN1kXpCxinOpD0FT/v9E+iDFEf1YMfMNG7mlN24aFUzHMJ9DUubK3p5O16DRXmqVeg==}
-    engines: {node: '>= 10.0.0'}
-    peerDependencies:
-      '@aws-sdk/signature-v4-crt': ^3.31.0
-    dependencies:
-      '@aws-sdk/protocol-http': 3.38.0
-      '@aws-sdk/signature-v4': 3.39.0
-      '@aws-sdk/types': 3.38.0
-      '@aws-sdk/util-arn-parser': 3.37.0
-      tslib: 2.3.1
     dev: false
 
   /@aws-sdk/middleware-sdk-s3/3.41.0:
@@ -1403,18 +855,6 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/middleware-sdk-sts/3.39.0:
-    resolution: {integrity: sha512-n9STxpg4tb50cleIHrgk36rVjRvWbxSSNaLMx94jhnXOAfCiSA0XRNrvymK92dCxm1rPX/c6etJkT6tVQ+8cdw==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/middleware-signing': 3.39.0
-      '@aws-sdk/property-provider': 3.38.0
-      '@aws-sdk/protocol-http': 3.38.0
-      '@aws-sdk/signature-v4': 3.39.0
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/middleware-sdk-sts/3.40.0:
     resolution: {integrity: sha512-TcrbCvj1PkabFZiNczT3yePZtuEm2fAIw1OVnQyLcF2KW+p62Hv5YkK4MPOfx3LA/0lzjOUO1RNl2x7gzV443Q==}
     engines: {node: '>= 10.0.0'}
@@ -1427,30 +867,11 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/middleware-serde/3.38.0:
-    resolution: {integrity: sha512-vtxaBe1KkXPaqVP8pKxdur5fGi+OH6aI1OkH4yUvmxrSZtDaECuhUn+Vl2ry6KSlvyzHD4DkgiUr0pgjK1/Peg==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/middleware-serde/3.40.0:
     resolution: {integrity: sha512-uOWfZjlAoBy6xPqp0d4ka83WNNbEVCWn9WwfqBUXThyoTdTooYSpXe5y2YzN0BJa8b+tEZTyWpgamnBpFLp47g==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/types': 3.40.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/middleware-signing/3.39.0:
-    resolution: {integrity: sha512-/ooDw0v8P3CXsWegjlThSdBvZcZ7V1xHc4ANmWUoWUupFgn4iC/Mdw7KrbJZaX8EtSzJC2cx1EsAnPxp4jlIyg==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/property-provider': 3.38.0
-      '@aws-sdk/protocol-http': 3.38.0
-      '@aws-sdk/signature-v4': 3.39.0
-      '@aws-sdk/types': 3.38.0
       tslib: 2.3.1
     dev: false
 
@@ -1465,14 +886,6 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/middleware-ssec/3.38.0:
-    resolution: {integrity: sha512-y2XyCRFfCMisZqyjMidt8myfLDvCcJpmVSmjksaryhE3f1yDdl3nYeJQncNsO/mbm1k2AMqPMV8SQu7YCX7+OA==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/middleware-ssec/3.40.0:
     resolution: {integrity: sha512-ZoRpaZeAIQa1Q+NyEh74ATwOR3nFGfcP6Nu0jFzgqoVijCReMnhtlCRx23ccBu1ZLZNUsNk6MhKjY+ZTfNsjEg==}
     engines: {node: '>= 10.0.0'}
@@ -1481,26 +894,10 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/middleware-stack/3.38.0:
-    resolution: {integrity: sha512-3M6ndxcaBvS8UL3yNMjj4NWnpkV2ZZoXtoiYdUIITTOOiaVCE3V69EcdASFYLdWu/D6VnVjF9MbZCAggppvQRA==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/middleware-stack/3.40.0:
     resolution: {integrity: sha512-hby9HvESUYJxpdALX+6Dn2LPmS5jtMVurGB/+j3MWOvIcDYB4bcSXgVRvXzYnTKwbSupIdbX9zOE2ZAx2SJpUQ==}
     engines: {node: '>= 10.0.0'}
     dependencies:
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/middleware-user-agent/3.38.0:
-    resolution: {integrity: sha512-ZGiGk6xlhtQULLceSXxM7KrMqfFMVkQ6yvtIn0BnJciNNnkF08FEyBq4cthvwFEO7SBGdc8XyEoi59xQP+gSkg==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/protocol-http': 3.38.0
-      '@aws-sdk/types': 3.38.0
       tslib: 2.3.1
     dev: false
 
@@ -1513,16 +910,6 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/node-config-provider/3.39.0:
-    resolution: {integrity: sha512-RCKt+5pzlsd56jhVEOE8UBKBYauPXjOGhaF8i191K61tRcvRdMBx2G1Di6sLiBzFdoKrMqBL3DJd73gsCWcqDA==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/property-provider': 3.38.0
-      '@aws-sdk/shared-ini-file-loader': 3.37.0
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/node-config-provider/3.40.0:
     resolution: {integrity: sha512-AmokjgUDECG8osoMfdRsPNweqI+L1pn4bYGk5iTLmzbBi0o4ot0U1FdX8Rf0qJZZwS4t1TXc3s8/PDVknmPxKg==}
     engines: {node: '>= 10.0.0'}
@@ -1530,17 +917,6 @@ packages:
       '@aws-sdk/property-provider': 3.40.0
       '@aws-sdk/shared-ini-file-loader': 3.37.0
       '@aws-sdk/types': 3.40.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/node-http-handler/3.38.0:
-    resolution: {integrity: sha512-acWeyvYMjAQAHZ6npXUiVfpGU+lLiVo8F+mC5t4v8vgy/yA1oXf8lC0XKKJRptnW2jKoyZzrWd5yRy1vBIa6Fg==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/abort-controller': 3.38.0
-      '@aws-sdk/protocol-http': 3.38.0
-      '@aws-sdk/querystring-builder': 3.38.0
-      '@aws-sdk/types': 3.38.0
       tslib: 2.3.1
     dev: false
 
@@ -1555,14 +931,6 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/property-provider/3.38.0:
-    resolution: {integrity: sha512-JLw1bw/PnA2QefaLe9CMlc/1JphIQT7Jq3JWhMz34ddZW3A45kVILwUW7klkiy/OcF/xUPs0gz45EEiUOhjj0w==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/property-provider/3.40.0:
     resolution: {integrity: sha512-Mx4lkShjsYRwW9ujHA1pcnuubrWQ4kF5/DXWNfUiXuSIO/0Lojp1qTLheyBm4vzkJIlx5umyP6NvRAUkEHSN4Q==}
     engines: {node: '>= 10.0.0'}
@@ -1571,28 +939,11 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/protocol-http/3.38.0:
-    resolution: {integrity: sha512-2z6QEJX16hvNoTZDmvrg8RIrnEv6hRCM4lELluFXE72T4FMfJpdsDWXTmQNHI8TyUcriyMjXztY62vOGNIzppg==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/protocol-http/3.40.0:
     resolution: {integrity: sha512-f4ea7/HZkjpvGBrnRIuzc/bhrExWrgDv7eulj4htPukZGHdTqSJD3Jk8lEXWvFuX2vUKQDGhEhCDsqup7YWJQQ==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/types': 3.40.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/querystring-builder/3.38.0:
-    resolution: {integrity: sha512-kvIYvkmPZDqHPNpEbSZPprqhtW25fq1fFgnHV9sGfKqkqnL+4LKMf2MmlKgKD+e7DaXAN3zkIaI9ibSjL/5UQQ==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.38.0
-      '@aws-sdk/util-uri-escape': 3.37.0
       tslib: 2.3.1
     dev: false
 
@@ -1605,14 +956,6 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/querystring-parser/3.38.0:
-    resolution: {integrity: sha512-rIzE+Rjmn7L0YBRrgZPzsqNu1NYSrW2v+BOdmQI8PMuhZ9T+gU6ttTTwpY/uVOmH8FeoaxWS+MRhI3FoV3eYOQ==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/querystring-parser/3.40.0:
     resolution: {integrity: sha512-XZIyaKQIiZAM6zelCBcsLHhVDOLafi7XIOd3jy6SymGN8ajj3HqUJ/vdQ5G6ISTk18OrqgqcCOI9oNzv+nrBcA==}
     engines: {node: '>= 10.0.0'}
@@ -1621,25 +964,20 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/s3-request-presigner/3.39.0:
-    resolution: {integrity: sha512-cLNLcFRoeY3cefkhR1gWz00I3260H/ju2ED2j5f8GYvzpsKHmQgR9Vibml4tVreaRP7tEN2gGuyTVs6PE15rjw==}
+  /@aws-sdk/s3-request-presigner/3.41.0:
+    resolution: {integrity: sha512-Kl9qtLrvtetz8lmcaXZWxu2Lr/d0JzPbs0xbKk9CO2QyXVLufczzksBucsjYovQ9iazMSr5lOKWLg2YPmNbZjw==}
     engines: {node: '>= 10.0.0'}
     dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.39.0
-      '@aws-sdk/protocol-http': 3.38.0
-      '@aws-sdk/signature-v4': 3.39.0
-      '@aws-sdk/smithy-client': 3.38.0
-      '@aws-sdk/types': 3.38.0
-      '@aws-sdk/util-create-request': 3.38.0
-      '@aws-sdk/util-format-url': 3.38.0
+      '@aws-sdk/middleware-sdk-s3': 3.41.0
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/signature-v4': 3.40.0
+      '@aws-sdk/smithy-client': 3.41.0
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/util-create-request': 3.41.0
+      '@aws-sdk/util-format-url': 3.40.0
       tslib: 2.3.1
     transitivePeerDependencies:
       - '@aws-sdk/signature-v4-crt'
-    dev: false
-
-  /@aws-sdk/service-error-classification/3.38.0:
-    resolution: {integrity: sha512-/lWkibTVZz2+/CwembYJ+ETMVlwFWF7UBKdwa6xRIbE+sp74c1li1L6d/PU83PolAt86bLTXaKpdpMsj+d1WAg==}
-    engines: {node: '>= 10.0.0'}
     dev: false
 
   /@aws-sdk/service-error-classification/3.40.0:
@@ -1654,17 +992,6 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/signature-v4/3.39.0:
-    resolution: {integrity: sha512-hGfO/ptA4oRy13/5eML21yayz1cuzTNK9MDUszFivw1Pdg7qk/605DSX551etEKvy9IAhPCXx7vbPuRujcj9qQ==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/is-array-buffer': 3.37.0
-      '@aws-sdk/types': 3.38.0
-      '@aws-sdk/util-hex-encoding': 3.37.0
-      '@aws-sdk/util-uri-escape': 3.37.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/signature-v4/3.40.0:
     resolution: {integrity: sha512-Q1GNZJRCS3W2qsRtDsX/b6EOSfMXfr6TW46N3LnLTGYZ3KAN2SOSJ1DsW59AuGpEZyRmOhJ9L/Q5U403+bZMXQ==}
     engines: {node: '>= 10.0.0'}
@@ -1673,15 +1000,6 @@ packages:
       '@aws-sdk/types': 3.40.0
       '@aws-sdk/util-hex-encoding': 3.37.0
       '@aws-sdk/util-uri-escape': 3.37.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/smithy-client/3.38.0:
-    resolution: {integrity: sha512-FRYE1eNCSl5hkW8XB8XnE6YrW4TmEGq/SgJqZIsPaH0eIYoKWAAzC295go6GR/BWdqTOIgJVps5fROh/5DqLmg==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/middleware-stack': 3.38.0
-      '@aws-sdk/types': 3.38.0
       tslib: 2.3.1
     dev: false
 
@@ -1694,22 +1012,9 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/types/3.38.0:
-    resolution: {integrity: sha512-Opux3HLwMlWb7GIJxERsOnmbHrT2A1gsd8aF5zHapWPPH5Z0rYsgTIq64qgim896XlKlOw6/YzhD5CdyNjlQWg==}
-    engines: {node: '>= 10.0.0'}
-    dev: false
-
   /@aws-sdk/types/3.40.0:
     resolution: {integrity: sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA==}
     engines: {node: '>= 10.0.0'}
-    dev: false
-
-  /@aws-sdk/url-parser/3.38.0:
-    resolution: {integrity: sha512-TQOc099wfrSEc2giCMQxKqMkYnI15QoDoDHelM5l/UHd1uvfB9Q1jZSvSvsaGVB7dG+OsrfiN5GHy0qOSwdxfQ==}
-    dependencies:
-      '@aws-sdk/querystring-parser': 3.38.0
-      '@aws-sdk/types': 3.38.0
-      tslib: 2.3.1
     dev: false
 
   /@aws-sdk/url-parser/3.40.0:
@@ -1769,13 +1074,13 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/util-create-request/3.38.0:
-    resolution: {integrity: sha512-+xIoXPa8Rut/lQ+KyFEwmb3cahFyuUeeXP4IU7IMXDArmnO8PYA5wQdFn1mKO/dPe3Kwef3J7tKB+S7vfVYmeA==}
+  /@aws-sdk/util-create-request/3.41.0:
+    resolution: {integrity: sha512-mKTMCDTaQ9HH+ppg1QMcBiSlbvRmw8AOllXTkYS1pdO7gi/Sl21krXfIja2MakuK6cB6D+B8MFP8rfq14Vhhlg==}
     engines: {node: '>= 10.0.0'}
     dependencies:
-      '@aws-sdk/middleware-stack': 3.38.0
-      '@aws-sdk/smithy-client': 3.38.0
-      '@aws-sdk/types': 3.38.0
+      '@aws-sdk/middleware-stack': 3.40.0
+      '@aws-sdk/smithy-client': 3.41.0
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 
@@ -1784,15 +1089,6 @@ packages:
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/shared-ini-file-loader': 3.37.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/util-format-url/3.38.0:
-    resolution: {integrity: sha512-x3bhcKsNZ/LDu4fsc3m67ZFQwxOHSXOC56rq/vT94vwfGgkEabJtOSL9U08k+M7jhXe9O5Qmery/Lu/ETtR++Q==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/querystring-builder': 3.38.0
-      '@aws-sdk/types': 3.38.0
       tslib: 2.3.1
     dev: false
 
@@ -1826,28 +1122,11 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@aws-sdk/util-user-agent-browser/3.38.0:
-    resolution: {integrity: sha512-u1SQns/U1RNiEQmTD1ND71sD2Dwqmb6uO6yu6AZ0ukr5sbrbNztCqpsJAFs3FbDa3WF3uieSzBy2JbpCo30nhw==}
-    dependencies:
-      '@aws-sdk/types': 3.38.0
-      bowser: 2.11.0
-      tslib: 2.3.1
-    dev: false
-
   /@aws-sdk/util-user-agent-browser/3.40.0:
     resolution: {integrity: sha512-C69sTI26bV2EprTv3DTXu9XP7kD9Wu4YVPBzqztOYArd2GDYw3w+jS8SEg3XRbjAKY/mOPZ2Thw4StjpZlWZiA==}
     dependencies:
       '@aws-sdk/types': 3.40.0
       bowser: 2.11.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/util-user-agent-node/3.39.0:
-    resolution: {integrity: sha512-uNFqhDCyOVjK6L8C1uR+AfWaslDqK180+VsWpWavtnefjstIKPbdqinu/yxaXDjL74oPbBc3wEyBpw21jeXFuA==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/node-config-provider': 3.39.0
-      '@aws-sdk/types': 3.38.0
       tslib: 2.3.1
     dev: false
 
@@ -1871,15 +1150,6 @@ packages:
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@aws-sdk/util-buffer-from': 3.37.0
-      tslib: 2.3.1
-    dev: false
-
-  /@aws-sdk/util-waiter/3.38.0:
-    resolution: {integrity: sha512-azH5C9GvrbXetjl5arxA8LjcZe5K1y2QR2JQ4ThXoRNhryyBAQF5qy+bn6Vv/LavKVM6VoM3g1zgN0JLVeYbyg==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@aws-sdk/abort-controller': 3.38.0
-      '@aws-sdk/types': 3.38.0
       tslib: 2.3.1
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,7 @@ importers:
   pkg/lib:
     specifiers:
       '@aws-sdk/client-cloudwatch-logs': ^3.41.0
+      '@aws-sdk/client-ec2': ^3.41.0
       '@types/aws-lambda': ^8.10.84
       '@violet/def': workspace:*
       '@violet/lib': workspace:*
@@ -185,6 +186,7 @@ importers:
       winston: ^3.3.3
     dependencies:
       '@aws-sdk/client-cloudwatch-logs': 3.41.0
+      '@aws-sdk/client-ec2': 3.41.0
       ballvalve: 3.1.3
       safe-stable-stringify: 2.2.0
       winston: 3.3.3
@@ -442,6 +444,48 @@ packages:
       '@aws-sdk/util-utf8-browser': 3.37.0
       '@aws-sdk/util-utf8-node': 3.37.0
       tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/client-ec2/3.41.0:
+    resolution: {integrity: sha512-IbThcHKAjNLPIaym6Z4EDnnJOTahQ7Y+Vu9OG+fLsCAeA4z6Py322c0SE2CcGnkliOm61LrZikhFdhSOAexOEw==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 2.0.0
+      '@aws-crypto/sha256-js': 2.0.0
+      '@aws-sdk/client-sts': 3.41.0
+      '@aws-sdk/config-resolver': 3.40.0
+      '@aws-sdk/credential-provider-node': 3.41.0
+      '@aws-sdk/fetch-http-handler': 3.40.0
+      '@aws-sdk/hash-node': 3.40.0
+      '@aws-sdk/invalid-dependency': 3.40.0
+      '@aws-sdk/middleware-content-length': 3.40.0
+      '@aws-sdk/middleware-host-header': 3.40.0
+      '@aws-sdk/middleware-logger': 3.40.0
+      '@aws-sdk/middleware-retry': 3.40.0
+      '@aws-sdk/middleware-sdk-ec2': 3.40.0
+      '@aws-sdk/middleware-serde': 3.40.0
+      '@aws-sdk/middleware-signing': 3.40.0
+      '@aws-sdk/middleware-stack': 3.40.0
+      '@aws-sdk/middleware-user-agent': 3.40.0
+      '@aws-sdk/node-config-provider': 3.40.0
+      '@aws-sdk/node-http-handler': 3.40.0
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/smithy-client': 3.41.0
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/url-parser': 3.40.0
+      '@aws-sdk/util-base64-browser': 3.37.0
+      '@aws-sdk/util-base64-node': 3.37.0
+      '@aws-sdk/util-body-length-browser': 3.37.0
+      '@aws-sdk/util-body-length-node': 3.37.0
+      '@aws-sdk/util-user-agent-browser': 3.40.0
+      '@aws-sdk/util-user-agent-node': 3.40.0
+      '@aws-sdk/util-utf8-browser': 3.37.0
+      '@aws-sdk/util-utf8-node': 3.37.0
+      '@aws-sdk/util-waiter': 3.40.0
+      entities: 2.2.0
+      fast-xml-parser: 3.19.0
+      tslib: 2.3.1
+      uuid: 8.3.2
     dev: false
 
   /@aws-sdk/client-s3/3.39.0:
@@ -1321,6 +1365,18 @@ packages:
       uuid: 8.3.2
     dev: false
 
+  /@aws-sdk/middleware-sdk-ec2/3.40.0:
+    resolution: {integrity: sha512-f6AXG5LlADhyyR1yirXfSKWOqu2uWAPHy0lNUZBnOBsYHbBiqVuQI9oyo1N9xtEHCmTFePYgfsdOdct9YuvAWw==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/protocol-http': 3.40.0
+      '@aws-sdk/signature-v4': 3.40.0
+      '@aws-sdk/types': 3.40.0
+      '@aws-sdk/util-format-url': 3.40.0
+      '@aws-sdk/util-uri-escape': 3.37.0
+      tslib: 2.3.1
+    dev: false
+
   /@aws-sdk/middleware-sdk-s3/3.39.0:
     resolution: {integrity: sha512-3vbMrUAqACIMJ/mORrV6AN1kXpCxinOpD0FT/v9E+iDFEf1YMfMNG7mlN24aFUzHMJ9DUubK3p5O16DRXmqVeg==}
     engines: {node: '>= 10.0.0'}
@@ -1737,6 +1793,15 @@ packages:
     dependencies:
       '@aws-sdk/querystring-builder': 3.38.0
       '@aws-sdk/types': 3.38.0
+      tslib: 2.3.1
+    dev: false
+
+  /@aws-sdk/util-format-url/3.40.0:
+    resolution: {integrity: sha512-eOKeYwAvsCQjTSCAW1LVhnjmTyyGK6lZjGTa9wXxxjVE6Fhc66+cCykS8u/u8Vj7BCS+ixiLetXtH1/qd+Bl+g==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      '@aws-sdk/querystring-builder': 3.40.0
+      '@aws-sdk/types': 3.40.0
       tslib: 2.3.1
     dev: false
 


### PR DESCRIPTION
## ℹ️ Info for Dev

- `.env.example` の更新
- docker-compose の再起動系を忘れずにお願いします

## Changes

- [x] 変換前後で bucket を分けました。prefix を定数として定義。
- [x] winston を導入しました。
  - TODO: エラーレベルを別で記録するのはまだです。
  - TODO: ログの書き方 wiki
- [x] Fastify のログ
  - winston でログ出しています。error, warn だけ流しています。
  - TODO: winston to fastify が若干雑なので後でちょっとした修正はするかもしれませんが、とりあえず取りこぼすことはないはず
- [x] ログを増やしました。
- [x] conv2img デプロイのための変更を含みます
- [x] conv2img いくつか追加でリファクタリングしました
  - `env` や `credentials` をエントリーポイントから引きずり回すように 
    - グローバル変数を避けている、なんか名前とかあるんですかね。
    - 今は全体で一種類の環境変数ですが、複数ある場合を考えるとこのほうが、何がほしいか明示的になってよいかなと思いました。
    - インフラの方は全部このパターンになっています
  - `s3` は `S3Client` + `send` ではなく `S3` を使うように。
    - 特に強い理由はないです。`send` 使うほうが internal っぽい感じがする。 インフラ側こちら使っているので特になければこちらに統一しますか、と思っていますがどうですか。
  - `getObject()` の整理。インライン化してしまってもいいかもしれないと少し思っている。
  - `putObject()` の削除・インライン化。書き方変えたとき、あまり util として活きていなかったので
  - 上記2つの詳細は https://github.com/violet-ts/violet/pull/105/commits/c3f23c6563303b556e9697a4bbb29199aa5b4265 の差分に
  - ファイル分割。max line 到達したので。
- [x] S3Event のあとに SQS や SNS が挟まっているパターンに対応 ( `findS3LocationsInEvent` )
- [x] `createBucketIfNotExists` 周辺の削除。 バケット存在の ensure 系は `mc` docker-compose に寄せました。もとの方法だと、どちらにせよバケットがないとイベントが登録できなくて順序が大変だったので。
- [x] ローカルでの conv2img 動作確認 (最終 https://github.com/violet-ts/violet/pull/105/commits/c3f23c6563303b556e9697a4bbb29199aa5b4265 )

## Issues

- resolves https://github.com/violet-ts/violet/issues/56
- resolves https://github.com/violet-ts/violet/issues/64
  - 2つ深くしました。 `works/original` と `works/converted`
- resolves https://github.com/violet-ts/violet/issues/96
  - bucket を分けました
