### PR TITLE
React Strict モード有効化

### DIFF
--- a/pkg/web/next.config.js
+++ b/pkg/web/next.config.js
@@ -1,5 +1,6 @@
 const withTM = require('next-transpile-modules')(['@violet/api', '@violet/def'])
 
 module.exports = withTM({
+  reactStrictMode: true,
   pageExtensions: ['page.tsx'],
 })


### PR DESCRIPTION
https://nextjs-ja-translation-docs.vercel.app/docs/api-reference/next.config.js/react-strict-mode

開発中のみ、たまにuseEffetchが意図的に2回呼ばれたりするようになる
（useEffetchは何度呼ばれてもアプリが壊れないようにするのが理想らしい）

私が書いた部分のuseEffetchが一番怪しいのでこれの影響でおかしい挙動が見つかったらIssue立ててください