### PR TITLE
chore: change apiWholeData to apiWholeDict

### DIFF
--- a/pkg/api/src/service/browser.ts
+++ b/pkg/api/src/service/browser.ts
@@ -72,7 +72,6 @@ export const getRevisions = async (workId: WorkId) => {
   const revisions = dbRevision.map(
     (r): ApiRevision => ({
       id: r.revisionId as RevisionId,
-      editionIds: [],
       messageIds: r.messages.map((m) => m.messageId as MessageId),
     })
   )
@@ -84,7 +83,7 @@ export const createRevision = async (workId: WorkId): Promise<ApiRevision> => {
   const revisionId = generateId<RevisionId>()
   await prisma.revision.create({ data: { revisionId, workId } })
 
-  return { id: revisionId, editionIds: [], messageIds: [] }
+  return { id: revisionId, messageIds: [] }
 }
 
 export const getDeskId = async (workId: WorkId) => {

--- a/pkg/lib/types/api.d.ts
+++ b/pkg/lib/types/api.d.ts
@@ -1,12 +1,4 @@
-import type {
-  DeskId,
-  EditionId,
-  MessageId,
-  ProjectId,
-  ReplyId,
-  RevisionId,
-  WorkId,
-} from './branded'
+import type { DeskId, MessageId, ProjectId, ReplyId, RevisionId, WorkId } from './branded'
 
 export type ApiProject = {
   id: ProjectId
@@ -28,7 +20,6 @@ export type ApiDesk = {
 
 export type ApiRevision = {
   id: RevisionId
-  editionIds: EditionId[] | undefined
   messageIds: MessageId[] | undefined
 }
 

--- a/pkg/lib/types/branded.d.ts
+++ b/pkg/lib/types/branded.d.ts
@@ -4,7 +4,6 @@ export type ProjectId = Branded<string, '__projectId'>
 export type DeskId = Branded<string, '__deskId'>
 export type WorkId = Branded<string, '__workId'>
 export type RevisionId = Branded<string, '__revisionId'>
-export type EditionId = Branded<string, '__editionId'>
 export type MessageId = Branded<string, '__messageId'>
 export type ResisteredUserId = Branded<string, '__resisteredUserId'>
 export type ReplyId = Branded<string, '__replyId'>

--- a/pkg/web/src/contexts/Browser.tsx
+++ b/pkg/web/src/contexts/Browser.tsx
@@ -1,24 +1,27 @@
+import type { ApiProject } from '@violet/lib/types/api'
 import { createContext, useCallback, useState } from 'react'
-import type { BrowserApiWholeData, BrowserProject } from '../types/browser'
+import type { BrowserApiWholeDict, BrowserProject } from '../types/browser'
 
 export const BrowserContext = createContext({
   projects: [] as BrowserProject[],
-  apiWholeData: {} as BrowserApiWholeData,
+  apiProjects: [] as ApiProject[],
+  apiWholeDict: {} as BrowserApiWholeDict,
   updateProjects: (() => {}) as (projects: BrowserProject[]) => void,
   updateProject: (() => {}) as (project: BrowserProject) => void,
-  updateApiWholeData: (() => {}) as <T extends keyof BrowserApiWholeData>(
+  updateApiProjects: (() => {}) as (apiProjects: ApiProject[]) => void,
+  updateApiWholeDict: (() => {}) as <T extends keyof BrowserApiWholeDict>(
     key: T,
-    data: BrowserApiWholeData[T]
+    dict: BrowserApiWholeDict[T]
   ) => void,
 })
 
 export const BrowserProvider: React.FC = ({ children }) => {
   const [projects, setProjects] = useState<BrowserProject[]>([])
-  const [apiWholeData, setApiWholeData] = useState<BrowserApiWholeData>({
-    projects: [],
-    desksList: [],
-    revisionsList: [],
-    messagesList: [],
+  const [apiProjects, setApiProjects] = useState<ApiProject[]>([])
+  const [apiWholeDict, setApiWholeDict] = useState<BrowserApiWholeDict>({
+    desksDict: {},
+    revisionsDict: {},
+    messagesDict: {},
   })
   const updateProjects = useCallback((projects: BrowserProject[]) => {
     setProjects(projects)
@@ -26,9 +29,12 @@ export const BrowserProvider: React.FC = ({ children }) => {
   const updateProject = useCallback((project: BrowserProject) => {
     setProjects((ps) => ps.map((p) => (p.id === project.id ? project : p)))
   }, [])
-  const updateApiWholeData = useCallback(
-    <T extends keyof BrowserApiWholeData>(key: T, data: BrowserApiWholeData[T]) => {
-      setApiWholeData((d) => ({ ...d, [key]: data }))
+  const updateApiProjects = useCallback((apiProjects: ApiProject[]) => {
+    setApiProjects(apiProjects)
+  }, [])
+  const updateApiWholeDict = useCallback(
+    <T extends keyof BrowserApiWholeDict>(key: T, dict: BrowserApiWholeDict[T]) => {
+      setApiWholeDict((d) => ({ ...d, [key]: { ...d[key], ...dict } }))
     },
     []
   )
@@ -37,10 +43,12 @@ export const BrowserProvider: React.FC = ({ children }) => {
     <BrowserContext.Provider
       value={{
         projects,
-        apiWholeData,
+        apiWholeDict,
+        apiProjects,
         updateProjects,
         updateProject,
-        updateApiWholeData,
+        updateApiProjects,
+        updateApiWholeDict,
       }}
     >
       {children}

--- a/pkg/web/src/pages/browser/[...pathes]/components/EmptyWork/index.tsx
+++ b/pkg/web/src/pages/browser/[...pathes]/components/EmptyWork/index.tsx
@@ -1,5 +1,4 @@
 import { acceptExtensions, fileTypes } from '@violet/def/constants'
-import type { ApiRevision } from '@violet/lib/types/api'
 import type { ProjectId, WorkId } from '@violet/lib/types/branded'
 import { CardModal } from '@violet/web/src/components/organisms/CardModal'
 import { BrowserContext } from '@violet/web/src/contexts/Browser'
@@ -66,7 +65,7 @@ const AlertMessage = styled.div`
 
 export const EmptyWork = (props: { projectId: ProjectId; workId: WorkId }) => {
   const { api, onErr } = useApi()
-  const { apiWholeData, updateApiWholeData } = useContext(BrowserContext)
+  const { updateApiWholeDict } = useContext(BrowserContext)
   const [dragging, setDragging] = useState(false)
   const [openAlert, setOpenAlert] = useState(false)
   const dragEnter = () => setDragging(true)
@@ -81,14 +80,6 @@ export const EmptyWork = (props: { projectId: ProjectId; workId: WorkId }) => {
     }
     e.target.value = ''
   }
-  const updateRevisions = (revisionRes: { workId: WorkId; revisions: ApiRevision[] }) => {
-    updateApiWholeData(
-      'revisionsList',
-      apiWholeData.revisionsList.some((r) => r.workId === revisionRes.workId)
-        ? apiWholeData.revisionsList.map((r) => (r.workId === revisionRes.workId ? revisionRes : r))
-        : [...apiWholeData.revisionsList, revisionRes]
-    )
-  }
   const sendFormData = async (file: FileList) => {
     setDragging(false)
     if (!file) return
@@ -101,7 +92,7 @@ export const EmptyWork = (props: { projectId: ProjectId; workId: WorkId }) => {
     const revisionRes = await api.browser.works._workId(props.workId).revisions.$get()
 
     if (!revisionRes) return
-    updateRevisions(revisionRes)
+    updateApiWholeDict('revisionsDict', revisionRes)
   }
 
   const closeModal = () => {

--- a/pkg/web/src/pages/browser/[...pathes]/components/Explorer/CellName.tsx
+++ b/pkg/web/src/pages/browser/[...pathes]/components/Explorer/CellName.tsx
@@ -74,7 +74,7 @@ export const CellName = (props: {
   const inputLabel = useCallback((e: ChangeEvent<HTMLInputElement>) => setLabel(e.target.value), [])
   const inputElement = useRef<HTMLInputElement>(null)
   const { api, onErr } = useApi()
-  const { apiWholeData, updateApiWholeData } = useContext(BrowserContext)
+  const { apiWholeDict, updateApiWholeDict } = useContext(BrowserContext)
   const { asPath, replace } = useRouter()
   const [editingType, setEditingType] = useState<'file' | 'folder'>('file')
   useEffect(() => {
@@ -103,19 +103,14 @@ export const CellName = (props: {
   }
   const submitNew = async (path: string, name: string, ext?: string) => {
     const { projectId, deskName } = getProjectInfo(pathChunks)
-    const desk = apiWholeData.desksList
-      .filter((d) => d.projectId === projectId)[0]
-      .desks.filter((d) => d.name === deskName)[0]
+    const desk = apiWholeDict.desksDict[projectId].filter((d) => d.name === deskName)[0]
     await api.browser.projects
       ._projectId(projectId)
       .desks._deskId(desk.id)
       .post({ body: { path, name, ext } })
       .catch(onErr)
     const deskRes = await api.browser.projects._projectId(projectId).desks.$get()
-    updateApiWholeData(
-      'desksList',
-      apiWholeData.desksList.map((d) => (d.projectId === deskRes.projectId ? deskRes : d))
-    )
+    updateApiWholeDict('desksDict', deskRes)
     replace(`${asPath}/${label}`)
     setIsClickNewAdd(false)
   }

--- a/pkg/web/src/pages/browser/[...pathes]/components/ProjectNameInput.tsx
+++ b/pkg/web/src/pages/browser/[...pathes]/components/ProjectNameInput.tsx
@@ -16,7 +16,7 @@ export const ProjectNameInput = (props: { onComplete?: () => void }) => {
   const inputLabel = useCallback((e: ChangeEvent<HTMLInputElement>) => setLabel(e.target.value), [])
   const inputElement = useRef<HTMLInputElement>(null)
   const { api, onErr } = useApi()
-  const { apiWholeData, projects, updateApiWholeData, updateProjects } = useContext(BrowserContext)
+  const { projects, apiProjects, updateApiProjects, updateProjects } = useContext(BrowserContext)
   const { asPath, push } = useRouter()
   const [isCreating, setIsCreating] = useState(false)
   useEffect(() => {
@@ -26,8 +26,8 @@ export const ProjectNameInput = (props: { onComplete?: () => void }) => {
     const newProject = await api.browser.projects.post({ body: { name } }).catch(onErr)
     if (!newProject?.body) return
 
-    const projectsData = [...apiWholeData.projects, newProject.body]
-    const projectsStatus = [
+    updateApiProjects([...apiProjects, newProject.body])
+    updateProjects([
       ...projects,
       {
         id: newProject.body.id,
@@ -37,9 +37,7 @@ export const ProjectNameInput = (props: { onComplete?: () => void }) => {
         selectedFullPath: newProject.body.id,
         tabs: [],
       },
-    ]
-    updateApiWholeData('projects', projectsData)
-    updateProjects(projectsStatus)
+    ])
     push(`${asPath}/${newProject.body.id}`)
   }
   const sendProjectName = async (e: FormEvent) => {

--- a/pkg/web/src/pages/browser/[...pathes]/components/ProjectNameUpdate.tsx
+++ b/pkg/web/src/pages/browser/[...pathes]/components/ProjectNameUpdate.tsx
@@ -15,7 +15,7 @@ export const ProjectNameUpdate = (props: { confirmName: () => void; projectId: P
   const inputLabel = useCallback((e: ChangeEvent<HTMLInputElement>) => setLabel(e.target.value), [])
   const inputElement = useRef<HTMLInputElement>(null)
   const { api, onErr } = useApi()
-  const { apiWholeData, projects, updateApiWholeData, updateProjects } = useContext(BrowserContext)
+  const { projects, apiProjects, updateApiProjects, updateProjects } = useContext(BrowserContext)
   const [isUpdating, setIsUpdating] = useState(false)
   useEffect(() => {
     inputElement.current?.focus()
@@ -28,13 +28,11 @@ export const ProjectNameUpdate = (props: { confirmName: () => void; projectId: P
       .catch(onErr)
     if (!projectData) return
 
-    const projectsData = apiWholeData.projects.map((d) =>
-      d.id === props.projectId ? projectData.body : d
-    )
+    const projectsData = apiProjects.map((d) => (d.id === props.projectId ? projectData.body : d))
     const projectsStatus = projects.map((d) =>
       d.id === props.projectId ? { ...d, name: projectData.body.name } : d
     )
-    updateApiWholeData('projects', projectsData)
+    updateApiProjects(projectsData)
     updateProjects(projectsStatus)
   }
 

--- a/pkg/web/src/pages/browser/[...pathes]/components/Revision/index.tsx
+++ b/pkg/web/src/pages/browser/[...pathes]/components/Revision/index.tsx
@@ -83,7 +83,7 @@ export const Revision = (props: {
   const [isFile, setIsFile] = useState(false)
   const [openAlert, setOpenAlert] = useState(false)
   const { api, onErr } = useApi()
-  const { apiWholeData, updateApiWholeData } = useContext(BrowserContext)
+  const { updateApiWholeDict } = useContext(BrowserContext)
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files?.length === 1) {
@@ -104,13 +104,7 @@ export const Revision = (props: {
       .catch(onErr)
 
     const revisionRes = await api.browser.works._workId(props.workId).revisions.$get()
-
-    if (!revisionRes) return
-
-    updateApiWholeData(
-      'revisionsList',
-      apiWholeData.revisionsList.map((r) => (r.workId === revisionRes.workId ? revisionRes : r))
-    )
+    updateApiWholeDict('revisionsDict', revisionRes)
   }
   const closeModal = () => {
     setOpenAlert(false)

--- a/pkg/web/src/pages/browser/[...pathes]/components/StreamBar/index.tsx
+++ b/pkg/web/src/pages/browser/[...pathes]/components/StreamBar/index.tsx
@@ -45,7 +45,7 @@ export const StreamBar = (props: {
   workId: WorkId
   revision: BrowserRevision
 }) => {
-  const { apiWholeData, updateApiWholeData } = useContext(BrowserContext)
+  const { updateApiWholeDict } = useContext(BrowserContext)
   const { api, onErr } = useApi()
   const [content, setContent] = useState('')
   const scrollBottomRef = useRef<HTMLDivElement>(null)
@@ -59,18 +59,15 @@ export const StreamBar = (props: {
       .post({ body: { content, userName } })
       .catch(onErr)
 
-    const messageRes = await api.browser.works
+    const messagesRes = await api.browser.works
       ._workId(props.workId)
       .revisions._revisionId(props.revision.id)
       .messages.$get()
+      .catch(onErr)
 
-    updateApiWholeData(
-      'messagesList',
-      apiWholeData.messagesList.map((m) =>
-        m.revisionId === messageRes.revisionId ? messageRes : m
-      )
-    )
+    if (!messagesRes) return
 
+    updateApiWholeDict('messagesDict', messagesRes)
     setContent('')
   }, [content])
 
@@ -95,10 +92,7 @@ export const StreamBar = (props: {
 
       if (!replyRes) return
 
-      updateApiWholeData(
-        'messagesList',
-        apiWholeData.messagesList.map((m) => (m.revisionId === replyRes.revisionId ? replyRes : m))
-      )
+      updateApiWholeDict('messagesDict', replyRes)
     },
     [content]
   )

--- a/pkg/web/src/pages/browser/[...pathes]/index.page.tsx
+++ b/pkg/web/src/pages/browser/[...pathes]/index.page.tsx
@@ -36,8 +36,7 @@ const ProjectPage = () => {
       projectApiData?.revisions?.map<BrowserRevision>((p) => ({
         id: p.id,
         editions: [],
-        messages:
-          projectApiData.messages?.filter((message) => p.messageIds?.includes(message.id)) ?? [],
+        messages: projectApiData.revisions?.filter((r) => r.id === p.id)[0].messages ?? [],
       })) ?? [],
     [projectApiData]
   )

--- a/pkg/web/src/pages/browser/[...pathes]/usePage.ts
+++ b/pkg/web/src/pages/browser/[...pathes]/usePage.ts
@@ -73,7 +73,7 @@ const getFullPath = (
 ) => `${projectId}${deskName ? `/${deskName}` : ''}${path ?? ''}`
 
 export const usePage = () => {
-  const { projects, apiWholeData, updateProject } = useContext(BrowserContext)
+  const { projects, apiProjects, apiWholeDict, updateProject } = useContext(BrowserContext)
   const { asPath, replace } = useRouter()
   const { projectId, deskName, path } = usePathValues()
   const currentProject = useMemo(
@@ -84,15 +84,10 @@ export const usePage = () => {
   const projectApiData = useMemo((): ProjectApiData | undefined => {
     if (!currentProject) return
 
-    const data = apiWholeData.projects?.find((p) => p.id === currentProject.id)
-    const desks = apiWholeData.desksList.find((d) => d.projectId === currentProject.id)?.desks
-    const revisions = apiWholeData.revisionsList.find(
-      (d) => d.workId === currentProject.openedTabId
-    )?.revisions
-
-    const messages = apiWholeData.messagesList
-      .filter((m) => revisions?.some((revision) => revision.id === m.revisionId))
-      ?.flatMap((m) => m.messages)
+    const data = apiProjects.find((p) => p.id === currentProject.id)
+    const desks = apiWholeDict.desksDict[currentProject.id]
+    const revisions =
+      currentProject.openedTabId && apiWholeDict.revisionsDict[currentProject.openedTabId]
 
     return (
       data &&
@@ -100,11 +95,10 @@ export const usePage = () => {
         projectId: currentProject.id,
         name: data.name,
         desks,
-        revisions,
-        messages,
+        revisions: revisions?.map((r) => ({ ...r, messages: apiWholeDict.messagesDict[r.id] })),
       }
     )
-  }, [apiWholeData, currentProject])
+  }, [apiWholeDict, currentProject])
 
   useEffect(() => {
     if (!currentProject || !projectApiData) return

--- a/pkg/web/src/types/browser.ts
+++ b/pkg/web/src/types/browser.ts
@@ -3,7 +3,6 @@
 import type { ApiDesk, ApiMessage, ApiProject, ApiRevision, ApiWork } from '@violet/lib/types/api'
 import type {
   DeskId,
-  EditionId,
   MessageId,
   ProjectId,
   ReplyId,
@@ -26,13 +25,8 @@ export type BrowserMessage = {
   replies: BrowserReply[]
 }
 
-export type BrowserEdition = {
-  id: EditionId
-}
-
 export type BrowserRevision = {
   id: RevisionId
-  editions: BrowserEdition[]
   messages: BrowserMessage[]
 }
 
@@ -70,17 +64,15 @@ export type BrowserProject = {
   openedFullPathDict: OpenedFullPathDict
 } & ApiProject
 
-export type BrowserApiWholeData = {
-  projects: ApiProject[]
-  desksList: { projectId: ProjectId; desks: ApiDesk[] }[]
-  revisionsList: { workId: WorkId; revisions: ApiRevision[] }[]
-  messagesList: { revisionId: RevisionId; messages: ApiMessage[] }[]
+export type BrowserApiWholeDict = {
+  desksDict: Record<ProjectId, ApiDesk[]>
+  revisionsDict: Record<WorkId, ApiRevision[]>
+  messagesDict: Record<RevisionId, ApiMessage[]>
 }
 
 export type ProjectApiData = {
   projectId: ProjectId
   name: string
   desks: ApiDesk[]
-  revisions: ApiRevision[] | undefined
-  messages: ApiMessage[] | undefined
+  revisions: BrowserRevision[] | undefined
 }


### PR DESCRIPTION
フロントリファクタリングの一部

- edition削除、DBは別のPRでまとめてマイグレーションする
- 全オブジェクト横断より親子間での探索がほとんどなのでwholeDataを配列から辞書に変更