### PR TITLE
webpとjpg/pngを使い分けてファイル表示

### DIFF
--- a/pkg/lambda/conv2img/src/convertObject.ts
+++ b/pkg/lambda/conv2img/src/convertObject.ts
@@ -1,7 +1,7 @@
 import type { Credentials, Provider } from '@aws-sdk/types'
 import { worksConvertedKeyPrefix, worksOriginalKeyPrefix } from '@violet/def/constants/s3'
 import type { VioletEnv } from '@violet/def/env/violet'
-import { FALLBACK_EXTS } from '@violet/lib/constants/file'
+import { CONTENT_TYPES, FALLBACK_EXTS } from '@violet/lib/constants/file'
 import { exec } from '@violet/lib/exec'
 import type { winston } from '@violet/lib/logger'
 import { replaceKeyPrefix } from '@violet/lib/s3'
@@ -11,12 +11,6 @@ import type { IncomingMessage } from 'http'
 import * as path from 'path'
 import { v4 as uuidv4 } from 'uuid'
 import { createS3Client, getObject } from './s3'
-
-const CONTENT_TYPES = {
-  webp: 'image/webp',
-  jpg: 'image/jpeg',
-  png: 'image/png',
-} as const
 
 export const LOCAL_DIR_NAMES = {
   tmp: '/tmp/tmp',

--- a/pkg/lib/constants/file.ts
+++ b/pkg/lib/constants/file.ts
@@ -1,1 +1,6 @@
-export const FALLBACK_EXTS = ['jpg', 'png'] as const
+export const FALLBACK_EXTS = ['jpg', 'png', 'webp'] as const
+export const CONTENT_TYPES = {
+  webp: 'image/webp',
+  jpg: 'image/jpeg',
+  png: 'image/png',
+} as const

--- a/pkg/lib/constants/file.ts
+++ b/pkg/lib/constants/file.ts
@@ -1,4 +1,4 @@
-export const FALLBACK_EXTS = ['jpg', 'png', 'webp'] as const
+export const FALLBACK_EXTS = ['jpg', 'png'] as const
 export const CONTENT_TYPES = {
   webp: 'image/webp',
   jpg: 'image/jpeg',

--- a/pkg/web/src/pages/browser/[[...paths]]/components/Revision/index.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/Revision/index.tsx
@@ -1,4 +1,5 @@
 import { acceptExtensions } from '@violet/def/constants'
+import { CONTENT_TYPES } from '@violet/lib/constants/file'
 import type { ApiRevision } from '@violet/lib/types/api'
 import type { ProjectId, RevisionPath, WorkId } from '@violet/lib/types/branded'
 import type { InfoJson } from '@violet/lib/types/files'
@@ -101,7 +102,13 @@ export const Revision = (props: {
       {isFile && <Dropper type="file" accept={acceptExtensions} />}
       <DisplayWorksFrame>
         {workPath.map((p) => (
-          <DisplayWorksViewer key={p} src={p} />
+          <picture key={p}>
+            <source
+              type={CONTENT_TYPES.webp}
+              srcSet={`${p.substring(0, p.lastIndexOf('.'))}.webp`}
+            />
+            <DisplayWorksViewer src={p} />
+          </picture>
         ))}
       </DisplayWorksFrame>
     </Container>


### PR DESCRIPTION
# Overview
- Resolves #136 
    - 対応しているブラウザではWebPで表示
    - それ以外のブラウザではinfo.jsonに記載された拡張子のファイルで表示


## Chrome
<img width="1440" alt="webp" src="https://user-images.githubusercontent.com/52160187/145307793-7604512e-870d-4c2b-a8f0-69fa59418615.png">

## Safari
<img width="1440" alt="safari" src="https://user-images.githubusercontent.com/52160187/145307812-3ae45afe-bc23-4f60-abcd-662065c28572.png">
