### PR TITLE
PaginationバーでGridスクロール

### DIFF
--- a/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn.tsx
@@ -68,6 +68,33 @@ export const MainColumn = (props: {
     })
   }
 
+  const onScroll = (element: React.UIEvent<HTMLDivElement>, index: number) => {
+    const clientHeight = element.currentTarget.clientHeight
+    const scrollHeight = element.currentTarget.scrollHeight
+    const scrollTop = element.currentTarget.scrollTop
+
+    if (scrollTop === 0) {
+      clickPagenation('previousPage', index)
+    }
+    if (scrollHeight === scrollTop + clientHeight) {
+      clickPagenation('nextPage', index)
+    }
+  }
+
+  const onWheel = (element: React.WheelEvent<HTMLDivElement>, index: number) => {
+    const clientHeight = element.currentTarget.clientHeight
+    const view = window.innerHeight
+    const direction = element.deltaY
+
+    if (clientHeight > view) onScroll(element, index)
+    if (Math.sign(direction) === -1) {
+      clickPagenation('previousPage', index)
+    }
+    if (Math.sign(direction) === 1) {
+      clickPagenation('nextPage', index)
+    }
+  }
+
   const dropFile = (file: File) => {
     const searchFileType = fileTypes.some((f) => file.type === f.type)
     if (searchFileType) {
@@ -84,7 +111,7 @@ export const MainColumn = (props: {
   const clickPagenation = (pageDirection: PageDirection, index: number) => {
     const targetRef =
       pageDirection === 'previousPage' ? refs.current[index - 1] : refs.current[index + 1]
-    targetRef?.current?.scrollIntoView()
+    targetRef?.current?.scrollIntoView({ behavior: 'smooth' })
   }
 
   return (
@@ -97,7 +124,7 @@ export const MainColumn = (props: {
               <FileUpload type="file" accept={acceptExtensions} onChange={onChange} />
             </AddButton>
           </ToolBar>
-          <RevisionContent>
+          <RevisionContent onWheel={(e) => onWheel(e, i)}>
             <Revision
               projectId={props.projectId}
               workId={props.workId}

--- a/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn.tsx
@@ -17,11 +17,15 @@ import { StreamBar } from './StreamBar'
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  width: 100%;
+  width: calc(100% + 18px);
   height: ${mainColumnHeight};
+  scroll-snap-type: y mandatory;
+  overflow-y: auto;
 `
 const MainContent = styled.div`
   display: flex;
+  width: calc(100% - 22px);
+  scroll-snap-align: start;
 `
 const RevisionContent = styled.div`
   flex: 1;
@@ -68,33 +72,6 @@ export const MainColumn = (props: {
     })
   }
 
-  const onScroll = (element: React.UIEvent<HTMLDivElement>, index: number) => {
-    const clientHeight = element.currentTarget.clientHeight
-    const scrollHeight = element.currentTarget.scrollHeight
-    const scrollTop = element.currentTarget.scrollTop
-
-    if (scrollTop === 0) {
-      clickPagenation('previousPage', index)
-    }
-    if (scrollHeight === scrollTop + clientHeight) {
-      clickPagenation('nextPage', index)
-    }
-  }
-
-  const onWheel = (element: React.WheelEvent<HTMLDivElement>, index: number) => {
-    const clientHeight = element.currentTarget.clientHeight
-    const view = window.innerHeight
-    const direction = element.deltaY
-
-    if (clientHeight > view) onScroll(element, index)
-    if (Math.sign(direction) === -1) {
-      clickPagenation('previousPage', index)
-    }
-    if (Math.sign(direction) === 1) {
-      clickPagenation('nextPage', index)
-    }
-  }
-
   const dropFile = (file: File) => {
     const searchFileType = fileTypes.some((f) => file.type === f.type)
     if (searchFileType) {
@@ -124,7 +101,7 @@ export const MainColumn = (props: {
               <FileUpload type="file" accept={acceptExtensions} onChange={onChange} />
             </AddButton>
           </ToolBar>
-          <RevisionContent onWheel={(e) => onWheel(e, i)}>
+          <RevisionContent>
             <Revision
               projectId={props.projectId}
               workId={props.workId}

--- a/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn.tsx
@@ -24,7 +24,7 @@ const Container = styled.div`
 `
 const MainContent = styled.div`
   display: flex;
-  width: calc(100% - 22px);
+  width: 100%;
   scroll-snap-align: start;
 `
 const RevisionContent = styled.div`

--- a/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn.tsx
@@ -85,7 +85,7 @@ export const MainColumn = (props: {
     }
     e.target.value = ''
   }
-  const clickPagenation = (pageDirection: PageDirection, index: number) => {
+  const clickPagination = (pageDirection: PageDirection, index: number) => {
     const targetRef =
       pageDirection === 'previousPage' ? refs.current[index - 1] : refs.current[index + 1]
     targetRef?.current?.scrollIntoView({ behavior: 'smooth' })
@@ -96,7 +96,7 @@ export const MainColumn = (props: {
       {props.revisions.map((revision, i) => (
         <MainContent key={revision.id} ref={refs.current[i]}>
           <ToolBar>
-            <PaginationBar clickPagenation={(result) => clickPagenation(result, i)} />
+            <PaginationBar clickPagination={(result) => clickPagination(result, i)} />
             <AddButton>
               <FileUpload type="file" accept={acceptExtensions} onChange={onChange} />
             </AddButton>

--- a/pkg/web/src/pages/browser/[[...paths]]/components/PaginationBar.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/PaginationBar.tsx
@@ -20,14 +20,14 @@ const NextPage = styled.div`
 `
 
 export const PaginationBar = (props: {
-  clickPagenation: (pageDirection: PageDirection) => void
+  clickPagination: (pageDirection: PageDirection) => void
 }) => {
   return (
     <Container>
-      <PreviousPage onClick={() => props.clickPagenation('previousPage')}>
+      <PreviousPage onClick={() => props.clickPagination('previousPage')}>
         <Chevron />
       </PreviousPage>
-      <NextPage onClick={() => props.clickPagenation('nextPage')}>
+      <NextPage onClick={() => props.clickPagination('nextPage')}>
         <Chevron />
       </NextPage>
     </Container>

--- a/pkg/web/src/pages/browser/[[...paths]]/components/StreamBar/index.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/StreamBar/index.tsx
@@ -20,6 +20,7 @@ const StreamBox = styled.div`
   bottom: 0;
   flex: 1;
   min-height: 80px;
+  overflow-x: hidden;
   overflow-y: auto;
 `
 const MessageBox = styled.div`

--- a/pkg/web/src/pages/browser/[[...paths]]/index.page.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/index.page.tsx
@@ -30,7 +30,7 @@ const WorksView = styled.div`
 `
 const WorksMain = styled.div`
   height: ${mainColumnHeight};
-  overflow-y: auto;
+  overflow: hidden;
 `
 
 const Columns = (props: {


### PR DESCRIPTION
## Overview
- Resolves #148 , Resolves #88 
    - 一番上の階層の階層を overflow: hidden にする
    - 最上部・最下部までスクロールしたときに次のリビジョンに上下矢印ボタンで作成した
        ScrollIntoViewを使用してグリッドスクロールする
        - position: absolute + transition + top: -n * 100% としたときに、
            flexが崩れてしまうため
