### PR TITLE
Pagination Bar を右側に移動・コメント追加時の自動スクロール修正

### DIFF
--- a/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn.tsx
@@ -17,10 +17,14 @@ import { StreamBar } from './StreamBar'
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  width: calc(100% + 18px);
+  width: 100%;
   height: ${mainColumnHeight};
   scroll-snap-type: y mandatory;
   overflow-y: auto;
+  scrollbar-width: none;
+  ::-webkit-scrollbar {
+    width: 0;
+  }
 `
 const MainContent = styled.div`
   display: flex;
@@ -95,12 +99,6 @@ export const MainColumn = (props: {
     <Container>
       {props.revisions.map((revision, i) => (
         <MainContent key={revision.id} ref={refs.current[i]}>
-          <ToolBar>
-            <PaginationBar clickPagination={(result) => clickPagination(result, i)} />
-            <AddButton>
-              <FileUpload type="file" accept={acceptExtensions} onChange={onChange} />
-            </AddButton>
-          </ToolBar>
           <RevisionContent>
             <Revision
               projectId={props.projectId}
@@ -113,6 +111,12 @@ export const MainColumn = (props: {
           <StreamBarColumn>
             <StreamBar projectId={props.projectId} workId={props.workId} revision={revision} />
           </StreamBarColumn>
+          <ToolBar>
+            <PaginationBar clickPagination={(result) => clickPagination(result, i)} />
+            <AddButton>
+              <FileUpload type="file" accept={acceptExtensions} onChange={onChange} />
+            </AddButton>
+          </ToolBar>
         </MainContent>
       ))}
       <AlertModal open={open} onClose={() => setOpen(false)} />

--- a/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn.tsx
@@ -6,7 +6,7 @@ import { useApiContext } from '@violet/web/src/contexts/Api'
 import { useBrowserContext } from '@violet/web/src/contexts/Browser'
 import type { BrowserRevision } from '@violet/web/src/types/browser'
 import type { PageDirection } from '@violet/web/src/types/tools'
-import { mainColumnHeight } from '@violet/web/src/utils/constants'
+import { colors, mainColumnHeight } from '@violet/web/src/utils/constants'
 import React, { useRef, useState } from 'react'
 import styled from 'styled-components'
 import { PaginationBar } from './PaginationBar'
@@ -24,6 +24,7 @@ const Container = styled.div`
   scrollbar-width: none;
   ::-webkit-scrollbar {
     width: 0;
+    background-color: ${colors.white};
   }
 `
 const MainContent = styled.div`

--- a/pkg/web/src/pages/browser/[[...paths]]/components/Revision/index.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/Revision/index.tsx
@@ -69,7 +69,7 @@ export const Revision = (props: {
   dropFile: (file: File) => void
 }) => {
   const [isFile, setIsFile] = useState(false)
-  const [workPath, setWorkPath] = useState([props.revision.url])
+  const [workPath, setWorkPath] = useState<RevisionPath[]>()
   const { data, error } = useSWR(props.revision.url, fetcher)
   useEffect(() => {
     if (data !== undefined) setWorkPath(data)
@@ -101,7 +101,7 @@ export const Revision = (props: {
     >
       {isFile && <Dropper type="file" accept={acceptExtensions} />}
       <DisplayWorksFrame>
-        {workPath.map((p) => (
+        {workPath?.map((p) => (
           <picture key={p}>
             <source
               type={CONTENT_TYPES.webp}

--- a/pkg/web/src/pages/browser/[[...paths]]/components/StreamBar/ReplyInputForm.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/StreamBar/ReplyInputForm.tsx
@@ -18,7 +18,10 @@ const InputForm = styled.textarea`
   }
 `
 const ClickableArea = styled.div`
+  display: flex;
+  flex-direction: column;
   justify-content: flex-end;
+  width: 24px;
   cursor: pointer;
 `
 export const ReplyInputForm = (props: { sendContent: (content: string) => void }) => {
@@ -31,10 +34,10 @@ export const ReplyInputForm = (props: { sendContent: (content: string) => void }
     <Container>
       <Spacer axis="x" size={4} />
       <InputForm placeholder="reply" value={content} onChange={(e) => setContent(e.target.value)} />
-      <Spacer axis="x" size={8} />
+      <Spacer axis="x" size={4} />
       <ClickableArea onClick={replyButtonClick}>
-        <Spacer axis="y" size={40} />
         <PencilIcon />
+        <Spacer axis="y" size={16} />
       </ClickableArea>
     </Container>
   )

--- a/pkg/web/src/pages/browser/[[...paths]]/components/StreamBar/index.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/StreamBar/index.tsx
@@ -14,6 +14,7 @@ const Container = styled.div`
   flex-direction: column;
   width: 300px;
   height: 100%;
+  border-right: 1px solid ${colors.violet}${alphaLevel[2]};
   border-left: 1px solid ${colors.violet}${alphaLevel[2]};
 `
 const StreamBox = styled.div`
@@ -22,12 +23,17 @@ const StreamBox = styled.div`
   min-height: 80px;
   overflow-x: hidden;
   overflow-y: auto;
+  scrollbar-width: none;
+  ::-webkit-scrollbar {
+    width: 0;
+    background-color: ${colors.white};
+  }
 `
 const MessageBox = styled.div`
   display: flex;
   flex-shrink: 0;
   justify-content: flex-end;
-  padding: 8px;
+  padding: 4px;
 `
 const InputForm = styled.textarea`
   flex: 1;
@@ -39,6 +45,10 @@ const InputForm = styled.textarea`
   }
 `
 const ClickableArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  width: 24px;
   cursor: pointer;
 `
 
@@ -136,8 +146,8 @@ export const StreamBar = (props: {
           onChange={(e) => setContent(e.target.value)}
         />
         <ClickableArea onClick={submitMessage}>
-          <Spacer axis="y" size={88} />
           <PencilIcon />
+          <Spacer axis="y" size={16} />
         </ClickableArea>
       </MessageBox>
     </Container>

--- a/pkg/web/src/pages/browser/[[...paths]]/components/StreamBar/index.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/StreamBar/index.tsx
@@ -99,7 +99,7 @@ export const StreamBar = (props: {
 
   useEffect(() => {
     scrollBottomRef.current?.scrollTo(0, scrollBottomRef.current?.scrollHeight || 0)
-  }, [scrollBottomRef.current?.scrollHeight])
+  }, [messages?.length])
 
   const replyMessage = useCallback(
     async (messageId: MessageId, content: string) => {

--- a/pkg/web/src/pages/browser/[[...paths]]/components/StreamBar/index.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/StreamBar/index.tsx
@@ -88,8 +88,8 @@ export const StreamBar = (props: {
   ])
 
   useEffect(() => {
-    scrollBottomRef?.current?.scrollIntoView()
-  }, [messages?.length])
+    scrollBottomRef.current?.scrollTo(0, scrollBottomRef.current?.scrollHeight || 0)
+  }, [scrollBottomRef.current?.scrollHeight])
 
   const replyMessage = useCallback(
     async (messageId: MessageId, content: string) => {
@@ -124,11 +124,10 @@ export const StreamBar = (props: {
 
   return (
     <Container>
-      <StreamBox>
+      <StreamBox ref={scrollBottomRef}>
         {messages?.map((m) => (
           <MessageCell key={m.id} message={m} replyMessage={replyMessage} />
         ))}
-        <div ref={scrollBottomRef} />
       </StreamBox>
       <MessageBox>
         <InputForm


### PR DESCRIPTION
## Overviews
- Resolved #153 
    - 画面の外側に出していたスクロールバーをwindowの中に戻す
       - webkit-scrollbar で非表示にする
       - scrollbar-width: none; で非表示にする（FireFox対応）
- Resolved #150 
    - コメントが追加されたときにscrollIntoViewで移動していた処理を
        スクロールバーがscrollheightの最下部に移動する処理に修正
- Resolved #154 
    - リビジョンで表示するファイルの変数の初期値を修正
 
## 画面イメージ
![image](https://user-images.githubusercontent.com/52160187/146628512-09fe5bbd-c9d0-4539-a01c-52487f33f5a7.png)

