### PR TITLE
プロジェクト名とプロジェクトアイコンをアップデート時のメモリリーク対応

### DIFF
--- a/pkg/web/src/pages/browser/[[...paths]]/components/ProjectConfig.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/ProjectConfig.tsx
@@ -6,6 +6,7 @@ import { Spacer } from '@violet/web/src/components/atoms/Spacer'
 import { useApiContext } from '@violet/web/src/contexts/Api'
 import { useBrowserContext } from '@violet/web/src/contexts/Browser'
 import type { BrowserProject } from '@violet/web/src/types/browser'
+import { parsePath } from '@violet/web/src/utils'
 import { pagesPath } from '@violet/web/src/utils/$path'
 import { colors, fontSizes } from '@violet/web/src/utils/constants'
 import { useRouter } from 'next/router'
@@ -83,7 +84,7 @@ export const ProjectConfig = (props: { onComplete?: () => void; project: Browser
 
     setIsUpdating(true)
     const projectName = newProjectName ? newProjectName : props.project.name
-    const projectUrlArray = asPath.split('/')
+    const { dirOrWorkNames } = parsePath(asPath)
     const iconName = createIconName()
     const projectRes = await api.browser.projects
       ._projectId(projectId)
@@ -95,7 +96,7 @@ export const ProjectConfig = (props: { onComplete?: () => void; project: Browser
     props.onComplete?.()
     if (projectRes) {
       updateProject(projectRes)
-      await push(pagesPath.browser._paths([projectName, ...projectUrlArray.slice(3)]).$url())
+      await push(pagesPath.browser._paths([projectName, ...dirOrWorkNames]).$url())
     }
 
     return undefined

--- a/pkg/web/src/pages/browser/[[...paths]]/components/ProjectConfig.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/ProjectConfig.tsx
@@ -88,9 +88,9 @@ export const ProjectConfig = (props: { onComplete?: () => void; project: Browser
       })
       .catch(onErr)
     setIsUpdating(false)
+    props.onComplete?.()
     if (projectRes) updateProject(projectRes)
 
-    props.onComplete?.()
     return undefined
   }
 

--- a/pkg/web/src/pages/browser/[[...paths]]/components/ProjectConfig.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/ProjectConfig.tsx
@@ -6,8 +6,9 @@ import { Spacer } from '@violet/web/src/components/atoms/Spacer'
 import { useApiContext } from '@violet/web/src/contexts/Api'
 import { useBrowserContext } from '@violet/web/src/contexts/Browser'
 import type { BrowserProject } from '@violet/web/src/types/browser'
+import { pagesPath } from '@violet/web/src/utils/$path'
 import { colors, fontSizes } from '@violet/web/src/utils/constants'
-import { useRouter } from 'next/dist/client/router'
+import { useRouter } from 'next/router'
 import type { ChangeEvent } from 'react'
 import React, { useState } from 'react'
 import styled from 'styled-components'
@@ -74,7 +75,7 @@ export const ProjectConfig = (props: { onComplete?: () => void; project: Browser
   const [newProjectName, setNewProjectName] = useState('')
   const { updateProject } = useBrowserContext()
   const { api, onErr } = useApiContext()
-  const { asPath, replace } = useRouter()
+  const { push, asPath } = useRouter()
   const [isUpdating, setIsUpdating] = useState(false)
 
   const updateProjectNameAndIcon = async (projectId: ProjectId) => {
@@ -82,7 +83,7 @@ export const ProjectConfig = (props: { onComplete?: () => void; project: Browser
 
     setIsUpdating(true)
     const projectName = newProjectName ? newProjectName : props.project.name
-    const projectUrl = asPath.replace(props.project.name, projectName)
+    const projectUrlArray = asPath.split('/')
     const iconName = createIconName()
     const projectRes = await api.browser.projects
       ._projectId(projectId)
@@ -94,7 +95,7 @@ export const ProjectConfig = (props: { onComplete?: () => void; project: Browser
     props.onComplete?.()
     if (projectRes) {
       updateProject(projectRes)
-      await replace(projectUrl)
+      await push(pagesPath.browser._paths([projectName, ...projectUrlArray.slice(3)]).$url())
     }
 
     return undefined

--- a/pkg/web/src/pages/browser/[[...paths]]/components/ProjectConfig.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/ProjectConfig.tsx
@@ -87,10 +87,11 @@ export const ProjectConfig = (props: { onComplete?: () => void; project: Browser
         body: { name: projectName, iconName, imageFile: iconImageFile },
       })
       .catch(onErr)
+    setIsUpdating(false)
     if (projectRes) updateProject(projectRes)
 
-    setIsUpdating(false)
-    return props.onComplete?.()
+    props.onComplete?.()
+    return undefined
   }
 
   const createIconName = () => {

--- a/pkg/web/src/pages/browser/[[...paths]]/components/ProjectConfig.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/ProjectConfig.tsx
@@ -6,7 +6,7 @@ import { Spacer } from '@violet/web/src/components/atoms/Spacer'
 import { useApiContext } from '@violet/web/src/contexts/Api'
 import { useBrowserContext } from '@violet/web/src/contexts/Browser'
 import type { BrowserProject } from '@violet/web/src/types/browser'
-import { parsePath } from '@violet/web/src/utils'
+import { useWorkPath } from '@violet/web/src/utils'
 import { pagesPath } from '@violet/web/src/utils/$path'
 import { colors, fontSizes } from '@violet/web/src/utils/constants'
 import { useRouter } from 'next/router'
@@ -76,15 +76,14 @@ export const ProjectConfig = (props: { onComplete?: () => void; project: Browser
   const [newProjectName, setNewProjectName] = useState('')
   const { updateProject } = useBrowserContext()
   const { api, onErr } = useApiContext()
-  const { push, asPath } = useRouter()
+  const { push } = useRouter()
   const [isUpdating, setIsUpdating] = useState(false)
-
+  const dirOrWorkNames = useWorkPath().dirOrWorkNames ?? []
   const updateProjectNameAndIcon = async (projectId: ProjectId) => {
     if (!newProjectName && !iconImageFile) return props.onComplete?.()
 
     setIsUpdating(true)
     const projectName = newProjectName ? newProjectName : props.project.name
-    const { dirOrWorkNames } = parsePath(asPath)
     const iconName = createIconName()
     const projectRes = await api.browser.projects
       ._projectId(projectId)

--- a/pkg/web/src/pages/browser/[[...paths]]/components/ProjectConfig.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/ProjectConfig.tsx
@@ -7,6 +7,7 @@ import { useApiContext } from '@violet/web/src/contexts/Api'
 import { useBrowserContext } from '@violet/web/src/contexts/Browser'
 import type { BrowserProject } from '@violet/web/src/types/browser'
 import { colors, fontSizes } from '@violet/web/src/utils/constants'
+import { useRouter } from 'next/dist/client/router'
 import type { ChangeEvent } from 'react'
 import React, { useState } from 'react'
 import styled from 'styled-components'
@@ -73,6 +74,7 @@ export const ProjectConfig = (props: { onComplete?: () => void; project: Browser
   const [newProjectName, setNewProjectName] = useState('')
   const { updateProject } = useBrowserContext()
   const { api, onErr } = useApiContext()
+  const { asPath, replace } = useRouter()
   const [isUpdating, setIsUpdating] = useState(false)
 
   const updateProjectNameAndIcon = async (projectId: ProjectId) => {
@@ -80,6 +82,7 @@ export const ProjectConfig = (props: { onComplete?: () => void; project: Browser
 
     setIsUpdating(true)
     const projectName = newProjectName ? newProjectName : props.project.name
+    const projectUrl = asPath.replace(props.project.name, projectName)
     const iconName = createIconName()
     const projectRes = await api.browser.projects
       ._projectId(projectId)
@@ -89,7 +92,10 @@ export const ProjectConfig = (props: { onComplete?: () => void; project: Browser
       .catch(onErr)
     setIsUpdating(false)
     props.onComplete?.()
-    if (projectRes) updateProject(projectRes)
+    if (projectRes) {
+      updateProject(projectRes)
+      await replace(projectUrl)
+    }
 
     return undefined
   }

--- a/pkg/web/src/pages/browser/[[...paths]]/components/ProjectNameUpdate.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/ProjectNameUpdate.tsx
@@ -2,6 +2,7 @@ import type { ProjectId } from '@violet/lib/types/branded'
 import { Loading } from '@violet/web/src/components/atoms/Loading'
 import { useApiContext } from '@violet/web/src/contexts/Api'
 import { useBrowserContext } from '@violet/web/src/contexts/Browser'
+import { useRouter } from 'next/dist/client/router'
 import type { ChangeEvent, Dispatch, FormEvent } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
@@ -33,6 +34,8 @@ export const ProjectNameUpdate: React.FC<Props> = ({
   const { api, onErr } = useApiContext()
   const { projects, updateProject } = useBrowserContext()
   const [isUpdating, setIsUpdating] = useState(false)
+  const { asPath, replace } = useRouter()
+  const currentProjectName = asPath.split('/')[2]
   const iconName =
     projects
       .find((d) => d.id === projectId)
@@ -47,13 +50,17 @@ export const ProjectNameUpdate: React.FC<Props> = ({
     if (!label) return
 
     setIsUpdating(true)
+    const projectUrl = asPath.replace(currentProjectName, label)
     const projectRes = await api.browser.projects
       ._projectId(projectId)
       .$put({ body: { name: label, iconName } })
       .catch(onErr)
     setIsUpdating(false)
     onConfirmName?.()
-    if (projectRes) updateProject(projectRes)
+    if (projectRes) {
+      updateProject(projectRes)
+      await replace(projectUrl)
+    }
   }
 
   return (

--- a/pkg/web/src/pages/browser/[[...paths]]/components/ProjectNameUpdate.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/ProjectNameUpdate.tsx
@@ -2,7 +2,8 @@ import type { ProjectId } from '@violet/lib/types/branded'
 import { Loading } from '@violet/web/src/components/atoms/Loading'
 import { useApiContext } from '@violet/web/src/contexts/Api'
 import { useBrowserContext } from '@violet/web/src/contexts/Browser'
-import { useRouter } from 'next/dist/client/router'
+import { pagesPath } from '@violet/web/src/utils/$path'
+import { useRouter } from 'next/router'
 import type { ChangeEvent, Dispatch, FormEvent } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
@@ -34,8 +35,8 @@ export const ProjectNameUpdate: React.FC<Props> = ({
   const { api, onErr } = useApiContext()
   const { projects, updateProject } = useBrowserContext()
   const [isUpdating, setIsUpdating] = useState(false)
-  const { asPath, replace } = useRouter()
-  const currentProjectName = asPath.split('/')[2]
+  const { push, asPath } = useRouter()
+  const projectUrlArray = asPath.split('/')
   const iconName =
     projects
       .find((d) => d.id === projectId)
@@ -50,7 +51,6 @@ export const ProjectNameUpdate: React.FC<Props> = ({
     if (!label) return
 
     setIsUpdating(true)
-    const projectUrl = asPath.replace(currentProjectName, label)
     const projectRes = await api.browser.projects
       ._projectId(projectId)
       .$put({ body: { name: label, iconName } })
@@ -59,7 +59,7 @@ export const ProjectNameUpdate: React.FC<Props> = ({
     onConfirmName?.()
     if (projectRes) {
       updateProject(projectRes)
-      await replace(projectUrl)
+      await push(pagesPath.browser._paths([label, ...projectUrlArray.slice(3)]).$url())
     }
   }
 

--- a/pkg/web/src/pages/browser/[[...paths]]/components/ProjectNameUpdate.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/ProjectNameUpdate.tsx
@@ -2,6 +2,7 @@ import type { ProjectId } from '@violet/lib/types/branded'
 import { Loading } from '@violet/web/src/components/atoms/Loading'
 import { useApiContext } from '@violet/web/src/contexts/Api'
 import { useBrowserContext } from '@violet/web/src/contexts/Browser'
+import { parsePath } from '@violet/web/src/utils'
 import { pagesPath } from '@violet/web/src/utils/$path'
 import { useRouter } from 'next/router'
 import type { ChangeEvent, Dispatch, FormEvent } from 'react'
@@ -36,7 +37,7 @@ export const ProjectNameUpdate: React.FC<Props> = ({
   const { projects, updateProject } = useBrowserContext()
   const [isUpdating, setIsUpdating] = useState(false)
   const { push, asPath } = useRouter()
-  const projectUrlArray = asPath.split('/')
+  const { dirOrWorkNames } = parsePath(asPath)
   const iconName =
     projects
       .find((d) => d.id === projectId)
@@ -59,7 +60,7 @@ export const ProjectNameUpdate: React.FC<Props> = ({
     onConfirmName?.()
     if (projectRes) {
       updateProject(projectRes)
-      await push(pagesPath.browser._paths([label, ...projectUrlArray.slice(3)]).$url())
+      await push(pagesPath.browser._paths([label, ...dirOrWorkNames]).$url())
     }
   }
 

--- a/pkg/web/src/pages/browser/[[...paths]]/components/ProjectNameUpdate.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/ProjectNameUpdate.tsx
@@ -42,24 +42,20 @@ export const ProjectNameUpdate: React.FC<Props> = ({
     inputElement.current?.focus()
   }, [])
 
-  const updateProjectName = async (name: string) => {
-    const projectRes = await api.browser.projects
-      ._projectId(projectId)
-      .$put({ body: { name, iconName } })
-      .catch(onErr)
-
-    if (projectRes) updateProject(projectRes)
-  }
-
   const updateName = async (e: FormEvent) => {
     e.preventDefault()
     if (!label) return
 
     setIsUpdating(true)
-    await updateProjectName(label)
+    const projectRes = await api.browser.projects
+      ._projectId(projectId)
+      .$put({ body: { name: label, iconName } })
+      .catch(onErr)
     setIsUpdating(false)
     onConfirmName?.()
+    if (projectRes) updateProject(projectRes)
   }
+
   return (
     <InputFormProject onSubmit={updateName}>
       <input ref={inputElement} type="text" onChange={inputLabel} />

--- a/pkg/web/src/pages/browser/[[...paths]]/components/ProjectNameUpdate.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/ProjectNameUpdate.tsx
@@ -2,7 +2,7 @@ import type { ProjectId } from '@violet/lib/types/branded'
 import { Loading } from '@violet/web/src/components/atoms/Loading'
 import { useApiContext } from '@violet/web/src/contexts/Api'
 import { useBrowserContext } from '@violet/web/src/contexts/Browser'
-import { parsePath } from '@violet/web/src/utils'
+import { useWorkPath } from '@violet/web/src/utils'
 import { pagesPath } from '@violet/web/src/utils/$path'
 import { useRouter } from 'next/router'
 import type { ChangeEvent, Dispatch, FormEvent } from 'react'
@@ -36,8 +36,8 @@ export const ProjectNameUpdate: React.FC<Props> = ({
   const { api, onErr } = useApiContext()
   const { projects, updateProject } = useBrowserContext()
   const [isUpdating, setIsUpdating] = useState(false)
-  const { push, asPath } = useRouter()
-  const { dirOrWorkNames } = parsePath(asPath)
+  const { push } = useRouter()
+  const dirOrWorkNames = useWorkPath().dirOrWorkNames ?? []
   const iconName =
     projects
       .find((d) => d.id === projectId)

--- a/pkg/web/src/pages/browser/[[...paths]]/usePage.ts
+++ b/pkg/web/src/pages/browser/[[...paths]]/usePage.ts
@@ -16,7 +16,6 @@ import type {
   OperationData,
   Tab,
 } from '@violet/web/src/types/browser'
-import { parsePath } from '@violet/web/src/utils'
 import { forceToggleHash } from '@violet/web/src/utils/constants'
 import { useRouter } from 'next/dist/client/router'
 import { useEffect, useMemo } from 'react'
@@ -138,8 +137,12 @@ export const usePage = ():
   | ({ error: Error } & { [P in keyof BrowserPageParams]?: undefined })
   | ({ error?: undefined } & BrowserPageParams) => {
   const { operationDataDict, projects, wholeDict, updateOperationData } = useBrowserContext()
-  const { asPath, replace } = useRouter()
-  const { projectName, dirOrWorkNames } = parsePath(asPath)
+  const { asPath, replace, query } = useRouter()
+  const { paths } = query
+  const { projectName, dirOrWorkNames } = useMemo(
+    () => (Array.isArray(paths) ? { projectName: paths[0], dirOrWorkNames: paths.slice(1) } : {}),
+    [paths]
+  )
   const currentProject = useMemo(
     () => projects.find((p) => p.name === projectName),
     [projects, projectName]

--- a/pkg/web/src/pages/browser/[[...paths]]/usePage.ts
+++ b/pkg/web/src/pages/browser/[[...paths]]/usePage.ts
@@ -16,6 +16,7 @@ import type {
   OperationData,
   Tab,
 } from '@violet/web/src/types/browser'
+import { useWorkPath } from '@violet/web/src/utils'
 import { forceToggleHash } from '@violet/web/src/utils/constants'
 import { useRouter } from 'next/dist/client/router'
 import { useEffect, useMemo } from 'react'
@@ -137,12 +138,8 @@ export const usePage = ():
   | ({ error: Error } & { [P in keyof BrowserPageParams]?: undefined })
   | ({ error?: undefined } & BrowserPageParams) => {
   const { operationDataDict, projects, wholeDict, updateOperationData } = useBrowserContext()
-  const { asPath, replace, query } = useRouter()
-  const { paths } = query
-  const { projectName, dirOrWorkNames } = useMemo(
-    () => (Array.isArray(paths) ? { projectName: paths[0], dirOrWorkNames: paths.slice(1) } : {}),
-    [paths]
-  )
+  const { asPath, replace } = useRouter()
+  const { projectName, dirOrWorkNames } = useWorkPath()
   const currentProject = useMemo(
     () => projects.find((p) => p.name === projectName),
     [projects, projectName]

--- a/pkg/web/src/pages/browser/[[...paths]]/usePage.ts
+++ b/pkg/web/src/pages/browser/[[...paths]]/usePage.ts
@@ -16,6 +16,7 @@ import type {
   OperationData,
   Tab,
 } from '@violet/web/src/types/browser'
+import { parsePath } from '@violet/web/src/utils'
 import { forceToggleHash } from '@violet/web/src/utils/constants'
 import { useRouter } from 'next/dist/client/router'
 import { useEffect, useMemo } from 'react'
@@ -137,12 +138,8 @@ export const usePage = ():
   | ({ error: Error } & { [P in keyof BrowserPageParams]?: undefined })
   | ({ error?: undefined } & BrowserPageParams) => {
   const { operationDataDict, projects, wholeDict, updateOperationData } = useBrowserContext()
-  const { asPath, replace, query } = useRouter()
-  const { paths } = query
-  const { projectName, dirOrWorkNames } = useMemo(
-    () => (Array.isArray(paths) ? { projectName: paths[0], dirOrWorkNames: paths.slice(1) } : {}),
-    [paths]
-  )
+  const { asPath, replace } = useRouter()
+  const { projectName, dirOrWorkNames } = parsePath(asPath)
   const currentProject = useMemo(
     () => projects.find((p) => p.name === projectName),
     [projects, projectName]

--- a/pkg/web/src/utils/index.ts
+++ b/pkg/web/src/utils/index.ts
@@ -41,3 +41,8 @@ export const tabToHref = (
         : [project.name]
     )
     .$url()
+
+export const parsePath = (projectPath: string) => ({
+  projectName: projectPath.split('/')[2],
+  dirOrWorkNames: projectPath.split('/').slice(3),
+})

--- a/pkg/web/src/utils/index.ts
+++ b/pkg/web/src/utils/index.ts
@@ -1,4 +1,6 @@
 import { pagesPath } from '@violet/web/src/utils/$path'
+import { useRouter } from 'next/router'
+import { useMemo } from 'react'
 import type {
   BrowserDir,
   BrowserProject,
@@ -42,7 +44,12 @@ export const tabToHref = (
     )
     .$url()
 
-export const parsePath = (projectPath: string) => ({
-  projectName: projectPath.split('/')[2],
-  dirOrWorkNames: projectPath.split('/').slice(3),
-})
+export const useWorkPath = () => {
+  const { query } = useRouter()
+  const { paths } = query
+  const { projectName, dirOrWorkNames } = useMemo(
+    () => (Array.isArray(paths) ? { projectName: paths[0], dirOrWorkNames: paths.slice(1) } : {}),
+    [paths]
+  )
+  return { projectName, dirOrWorkNames }
+}


### PR DESCRIPTION
プロジェクト名とプロジェクトアイコンを更新時にメモリリークになっていたのを修正しました。