### PR TITLE
ファイル名、フォルダ名ラベルの縦幅を修正

### DIFF
--- a/pkg/web/src/pages/browser/[[...paths]]/components/Explorer/CellName.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/Explorer/CellName.tsx
@@ -21,7 +21,7 @@ import { ActiveStyle } from '../Styles/ActiveStyle'
 
 const Container = styled.a<{ depth: number; active: boolean }>`
   display: block;
-  padding: 6px 8px;
+  padding: 5px 8px;
   padding-left: ${(props) => props.depth * 8}px;
   ${ActiveStyle};
 `
@@ -41,6 +41,7 @@ const LabelArea = styled.div`
 
 const Label = styled.div`
   flex: 1;
+  height: 18px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/pkg/web/src/pages/browser/[[...paths]]/components/ExtIcon.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/ExtIcon.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 const Container = styled.span<{ color: string }>`
   display: inline-block;
   width: 20px;
-  padding: 2px 0 4px;
+  padding: 4px;
   font-size: ${fontSizes.mini};
   color: ${colors.white};
   text-align: center;

--- a/pkg/web/src/pages/browser/[[...paths]]/components/Tab/Dragable.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/Tab/Dragable.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components'
 const DragItem = styled.div<{
   isDragging?: boolean
 }>`
+  display: flex;
   opacity: ${(props) => (props.isDragging ? 0.4 : 1)};
 `
 

--- a/pkg/web/src/pages/browser/[[...paths]]/components/Tab/TabBar.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/Tab/TabBar.tsx
@@ -32,6 +32,7 @@ const TabItem = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-evenly;
+  height: 100%;
   padding: 8px;
   border-right: 1px solid ${colors.violet}${alphaLevel[2]};
   ${ActiveStyle};


### PR DESCRIPTION
ファイル名、フォルダ名に「g」を入力すると文字が切れて表示されてしまう箇所を
修正しました。

修正後の画面
<img width="692" alt="ファイル名表示" src="https://user-images.githubusercontent.com/88891567/149652369-ba370b88-c022-48ec-9841-63bd7bf1c125.png">

修正前の画面
<img width="692" alt="修正前" src="https://user-images.githubusercontent.com/88891567/149652412-5c1c2a6e-64df-4a88-b544-4adca7b31c33.png">

