### PR TITLE
fix: CSRF Tokenの取り回しに関するバグを修正

### DIFF
--- a/pkg/web/src/contexts/Api.tsx
+++ b/pkg/web/src/contexts/Api.tsx
@@ -1,7 +1,7 @@
 import aspida from '@aspida/fetch'
 import useAspidaSWR from '@aspida/swr'
 import $api from '@violet/api/api/$api'
-import { createContext, useContext, useMemo } from 'react'
+import { createContext, useContext, useEffect, useMemo, useRef } from 'react'
 
 const ApiContext = createContext({
   api: $api(
@@ -15,25 +15,80 @@ const ApiContext = createContext({
 
 export const useApiContext = () => useContext(ApiContext)
 
+type ResolveCsrfToken = (csrfToken: string) => void
+type GetCsrfToken = Promise<string>
+type MutateCsrfToken = () => Promise<unknown>
+
 export const ApiProvider: React.FC = ({ children }) => {
+  const resolveCsrfToken = useRef<ResolveCsrfToken>()
+  const getCsrfToken = useRef<GetCsrfToken>()
+  const mutateCsrfToken = useRef<MutateCsrfToken>()
+
+  const resetCsrfTokenPromise = () => {
+    if (getCsrfToken.current === undefined) {
+      getCsrfToken.current = new Promise<string>((resolve) => {
+        resolveCsrfToken.current = resolve
+      })
+    }
+  }
+
+  resetCsrfTokenPromise()
+
   const plainApi = useMemo(
     () => $api(aspida(fetch, { credentials: 'include', throwHttpErrors: true })),
     []
   )
-  const { data: csrfToken } = useAspidaSWR(plainApi.csrf, {
+
+  const {
+    data: csrfToken,
+    mutate,
+    isValidating,
+  } = useAspidaSWR(plainApi.csrf, {
     refreshInterval: 1000 * 60 * 12, // 12 hours
   })
-  // TODO(service): 必須ではないが、csrf token で forbidden だったら一定数 mutate を自動でする、自動リトライする
+  useEffect(() => {
+    if (typeof csrfToken === 'string' && !isValidating) {
+      const oldResolve = resolveCsrfToken.current
+      getCsrfToken.current = Promise.resolve(csrfToken)
+      resolveCsrfToken.current = undefined
+      mutateCsrfToken.current = async () => {
+        // リセットすることで使用者側が確実に新しいトークンを取るようにする
+        getCsrfToken.current = undefined
+        resetCsrfTokenPromise()
+        await mutate()
+      }
+      oldResolve?.(csrfToken)
+    } else if (isValidating) {
+      resetCsrfTokenPromise()
+    }
+  }, [plainApi, csrfToken, mutate, isValidating])
+
+  // NOTE: この中で ref を経由せずにステートにアクセスしてはいけない。最新の（代入時点では未来の）ステートが知りたいため。
+  const customFetch: typeof fetch = async (input, init) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- depending on impl of aspida
+    ;(init!.headers as Record<string, string>)['csrf-token'] = await getCsrfToken.current!
+    {
+      const response = await fetch(input, init)
+      if (response.status !== 403) return response
+    }
+
+    // 403 (Forbidden) の際に自動リトライ
+    await mutateCsrfToken.current?.()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- depending on impl of aspida
+    ;(init!.headers as Record<string, string>)['csrf-token'] = await getCsrfToken.current!
+    const response = await fetch(input, init)
+    return response
+  }
+
   const api = useMemo(
     () =>
       $api(
-        aspida(fetch, {
+        aspida(customFetch, {
           credentials: 'include',
           throwHttpErrors: true,
-          headers: csrfToken ? { 'csrf-token': csrfToken } : {},
         })
       ),
-    [csrfToken]
+    []
   )
 
   return <ApiContext.Provider value={{ api, onErr: () => {} }}>{children}</ApiContext.Provider>


### PR DESCRIPTION
- [x] リクエスト時に csrf token が用意できていなければ待つようにする
  - ケース: ページを読み込んだ直後にGET以外の処理を行った場合
- [x] 403 forbidden 時に自動でリトライをする
  - ケース: サーバーを再起動などしてすべてのcsrf tokenが無効になった場合
  - ケース: csrf tokenが無効になる程度の長い時間開けて、サイドページを開いたあと、swrのisValidatingの更新がなされる前にGET以外をするような操作をした


`// TODO(service): 必須ではないが、csrf token で forbidden だったら一定数 mutate を自動でする、自動リトライする`

この TODO コメントを解消する PR です。

refを使ってのかなりメタい書き方になっているのは、何かしらのステートに対して、「そのステートが準備完了な状態になったらresolveする Promise」のような、react だけ（refを使わない）では実現できないため。

（これは実際のところほとんどめったに起こらない）