### PR TITLE
ファイル作成などのアクションをしようとするとファイルツリーも一緒に動作しまう処理の修正

### DIFF
--- a/pkg/web/src/pages/browser/[[...paths]]/components/Explorer/CellName.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/Explorer/CellName.tsx
@@ -147,6 +147,10 @@ export const CellName = (props: {
     inputElement.current?.focus()
   })
 
+  const openInputBox = (e: FormEvent) => {
+    e.stopPropagation()
+  }
+
   return (
     <Link href={href}>
       <Container depth={pathChunks.length - 1} active={props.active}>
@@ -161,7 +165,7 @@ export const CellName = (props: {
             <>
               <Arrow opened={props.opened} />
               <Spacer axis="x" size={18} />
-              <AddAreaParent>
+              <AddAreaParent onClick={openInputBox}>
                 <AddArea addWork={addWork} addDir={addDir} />
               </AddAreaParent>
               <Label>{props.dir.name}</Label>


### PR DESCRIPTION
ファイル・フォルダ作成ボタンを押下すると一緒にファイルツリーが動作してしまう処理を修正しました。
動作画面
![動作確認](https://user-images.githubusercontent.com/88891567/151655987-a220c192-d96f-41c5-9773-962a4ebcb9f2.gif)

