### PR TITLE
Dirタブ選択時のWork表示エリアUI作成

### DIFF
--- a/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn/DirTab.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn/DirTab.tsx
@@ -1,11 +1,5 @@
 import type { ApiProject } from '@violet/lib/types/api'
-import type { WorkId } from '@violet/lib/types/branded'
-import type {
-  BrowserRevision,
-  DirsDict,
-  OperationData,
-  WorksDict,
-} from '@violet/web/src/types/browser'
+import type { DirsDict, OperationData, WorksDict } from '@violet/web/src/types/browser'
 import { createPath } from '@violet/web/src/utils'
 import { alphaLevel, colors } from '@violet/web/src/utils/constants'
 import Link from 'next/link'
@@ -45,6 +39,7 @@ const DirFrame = styled.button`
 `
 const WorkFrame = styled.button`
   width: 24%;
+  max-width: 300px;
   padding: 8px;
   cursor: pointer;
   background-color: ${colors.white};
@@ -66,7 +61,6 @@ type ComponentProps = {
   operationData: OperationData
   dirsDict: DirsDict
   worksDict: WorksDict
-  revisionsForWorkId: Record<WorkId, BrowserRevision[] | undefined>
 }
 
 export const DirTab = ({ project, operationData, dirsDict, worksDict }: ComponentProps) => {
@@ -123,7 +117,9 @@ export const DirTab = ({ project, operationData, dirsDict, worksDict }: Componen
                 href={createPath(work.dirId, work.id, project, dirsDict, worksDict)}
                 passHref
               >
-                <WorkFrame>{work.name}</WorkFrame>
+                <WorkFrame>
+                  {work.latestRevisionId === null ? <div>No Revision</div> : <div>{work.name}</div>}
+                </WorkFrame>
               </Link>
             ))}
           </PartsContainer>

--- a/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn/DirTab.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn/DirTab.tsx
@@ -107,7 +107,7 @@ export const DirTab = ({ project, operationData, dirsDict, worksDict }: Componen
           </PartsContainer>
         </>
       )}
-      {displayedWorks !== null ? (
+      {displayedWorks && displayedWorks.length > 0 ? (
         <>
           <Label>Works</Label>
           <PartsContainer>
@@ -118,7 +118,8 @@ export const DirTab = ({ project, operationData, dirsDict, worksDict }: Componen
                 passHref
               >
                 <WorkFrame>
-                  {work.latestRevisionId === null ? <div>No Revision</div> : <div>{work.name}</div>}
+                  {work.latestRevisionId === null ? <div>No Revision</div> : <div>{work.id}</div>}
+                  <div>{work.name}</div>
                 </WorkFrame>
               </Link>
             ))}

--- a/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn/DirTab.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn/DirTab.tsx
@@ -93,7 +93,7 @@ export const DirTab = ({ project, operationData, dirsDict, worksDict }: Componen
     <Container>
       {displayedDirs && (
         <>
-          <Label>Directlies</Label>
+          <Label>Directories</Label>
           <PartsContainer>
             {childrenDir.map((dir) => (
               <Link
@@ -125,7 +125,7 @@ export const DirTab = ({ project, operationData, dirsDict, worksDict }: Componen
           </PartsContainer>
         </>
       ) : (
-        <EmptyMessage>Directly and Works has not been , yet.</EmptyMessage>
+        <EmptyMessage>Directory and Works has not been , yet.</EmptyMessage>
       )}
     </Container>
   )

--- a/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn/DirTab.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn/DirTab.tsx
@@ -1,0 +1,106 @@
+import type { ApiProject } from '@violet/lib/types/api'
+import type { DirsDict, OperationData, WorksDict } from '@violet/web/src/types/browser'
+import { alphaLevel, colors } from '@violet/web/src/utils/constants'
+import Link from 'next/link'
+import { useCallback } from 'react'
+import styled from 'styled-components'
+import { createPath } from '../../../../../utils'
+import { FontStyle } from '../Styles/PartsStyles'
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 8px;
+  overflow: overlay;
+`
+
+const Label = styled.div`
+  padding: 8px;
+  ${FontStyle}
+`
+
+const DirContainer = styled.div`
+  display: flex;
+  gap: 8px;
+  padding: 8px;
+`
+
+const DirsFrame = styled.button`
+  width: fit-content;
+  padding: 8px;
+  cursor: pointer;
+  background-color: ${colors.white};
+  border: 1px solid ${colors.violet}${alphaLevel[2]};
+  border-radius: 4px;
+  ${FontStyle}
+`
+
+const Message = styled.div`
+  width: fit-content;
+  padding: 8px;
+  border: 1px solid ${colors.violet}${alphaLevel[2]};
+  border-radius: 4px;
+  ${FontStyle}
+`
+
+type ComponentProps = {
+  project: ApiProject
+  operationData: OperationData
+  dirsDict: DirsDict
+  worksDict: WorksDict
+}
+
+export const DirTab = ({ project, operationData, dirsDict, worksDict }: ComponentProps) => {
+  const displayedDirs = useCallback(
+    () =>
+      Object.values(dirsDict)
+        .map((dir) => dir.parentDirId !== null && dir.parentDirId === operationData.activeTab?.id)
+        .includes(true),
+    [operationData, dirsDict]
+  )
+
+  const displayedWorks = useCallback(
+    () =>
+      operationData.activeTab &&
+      operationData.activeTab.type === 'dir' &&
+      dirsDict[operationData.activeTab.id].works.length > 0,
+    [operationData, dirsDict]
+  )
+
+  const childrenDir = useCallback(
+    () =>
+      Object.values(dirsDict).filter(
+        (dir) =>
+          operationData.activeTab?.type === 'dir' &&
+          dir.parentDirId === dirsDict[operationData.activeTab.id].id
+      ),
+    [operationData, dirsDict]
+  )
+
+  return (
+    <Container>
+      {displayedDirs() && (
+        <>
+          <Label>Directlies</Label>
+          <DirContainer>
+            {childrenDir().map((dir) => (
+              <Link
+                key={dir.id}
+                href={createPath(dir.id, undefined, project, dirsDict, worksDict)}
+                passHref
+              >
+                <DirsFrame>{dir.name} </DirsFrame>
+              </Link>
+            ))}
+          </DirContainer>
+        </>
+      )}
+      {displayedWorks() ? (
+        <Label>Works</Label>
+      ) : (
+        <Message>Directly and Works has not been, yet. </Message>
+      )}
+    </Container>
+  )
+}

--- a/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn/DirTab.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn/DirTab.tsx
@@ -6,16 +6,17 @@ import type {
   OperationData,
   WorksDict,
 } from '@violet/web/src/types/browser'
+import { createPath } from '@violet/web/src/utils'
 import { alphaLevel, colors } from '@violet/web/src/utils/constants'
 import Link from 'next/link'
-import { useCallback } from 'react'
+import { useMemo } from 'react'
 import styled from 'styled-components'
-import { createPath } from '../../../../../utils'
 import { FontStyle } from '../Styles/PartsStyles'
 
 const Container = styled.div`
   display: flex;
   flex-direction: column;
+  width: 100%;
   height: 100%;
   padding: 8px;
   overflow: overlay;
@@ -26,14 +27,24 @@ const Label = styled.div`
   ${FontStyle}
 `
 
-const DirContainer = styled.div`
+const PartsContainer = styled.div`
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   padding: 8px;
 `
 
-const DirsFrame = styled.button`
+const DirFrame = styled.button`
   width: fit-content;
+  padding: 8px;
+  cursor: pointer;
+  background-color: ${colors.white};
+  border: 1px solid ${colors.violet}${alphaLevel[2]};
+  border-radius: 4px;
+  ${FontStyle}
+`
+const WorkFrame = styled.button`
+  width: 24%;
   padding: 8px;
   cursor: pointer;
   background-color: ${colors.white};
@@ -59,7 +70,7 @@ type ComponentProps = {
 }
 
 export const DirTab = ({ project, operationData, dirsDict, worksDict }: ComponentProps) => {
-  const displayedDirs = useCallback(
+  const displayedDirs = useMemo(
     () =>
       Object.values(dirsDict)
         .map((dir) => dir.parentDirId !== null && dir.parentDirId === operationData.activeTab?.id)
@@ -67,15 +78,14 @@ export const DirTab = ({ project, operationData, dirsDict, worksDict }: Componen
     [operationData, dirsDict]
   )
 
-  const displayedWorks = useCallback(
-    () =>
-      operationData.activeTab &&
-      operationData.activeTab.type === 'dir' &&
-      dirsDict[operationData.activeTab.id].works.length > 0,
-    [operationData, dirsDict]
-  )
+  const displayedWorks = useMemo(() => {
+    if (operationData.activeTab && operationData.activeTab.type === 'dir') {
+      return dirsDict[operationData.activeTab.id].works
+    }
+    return null
+  }, [operationData, dirsDict])
 
-  const childrenDir = useCallback(
+  const childrenDir = useMemo(
     () =>
       Object.values(dirsDict).filter(
         (dir) =>
@@ -87,24 +97,37 @@ export const DirTab = ({ project, operationData, dirsDict, worksDict }: Componen
 
   return (
     <Container>
-      {displayedDirs() && (
+      {displayedDirs && (
         <>
           <Label>Directlies</Label>
-          <DirContainer>
-            {childrenDir().map((dir) => (
+          <PartsContainer>
+            {childrenDir.map((dir) => (
               <Link
                 key={dir.id}
                 href={createPath(dir.id, undefined, project, dirsDict, worksDict)}
                 passHref
               >
-                <DirsFrame>{dir.name} </DirsFrame>
+                <DirFrame>{dir.name}</DirFrame>
               </Link>
             ))}
-          </DirContainer>
+          </PartsContainer>
         </>
       )}
-      {displayedWorks() ? (
-        <Label>Works</Label>
+      {displayedWorks !== null ? (
+        <>
+          <Label>Works</Label>
+          <PartsContainer>
+            {displayedWorks?.map((work) => (
+              <Link
+                key={work.id}
+                href={createPath(work.dirId, work.id, project, dirsDict, worksDict)}
+                passHref
+              >
+                <WorkFrame>{work.name}</WorkFrame>
+              </Link>
+            ))}
+          </PartsContainer>
+        </>
       ) : (
         <EmptyMessage>Directly and Works has not been , yet.</EmptyMessage>
       )}

--- a/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn/DirTab.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/MainColumn/DirTab.tsx
@@ -1,5 +1,11 @@
 import type { ApiProject } from '@violet/lib/types/api'
-import type { DirsDict, OperationData, WorksDict } from '@violet/web/src/types/browser'
+import type { WorkId } from '@violet/lib/types/branded'
+import type {
+  BrowserRevision,
+  DirsDict,
+  OperationData,
+  WorksDict,
+} from '@violet/web/src/types/browser'
 import { alphaLevel, colors } from '@violet/web/src/utils/constants'
 import Link from 'next/link'
 import { useCallback } from 'react'
@@ -36,7 +42,7 @@ const DirsFrame = styled.button`
   ${FontStyle}
 `
 
-const Message = styled.div`
+const EmptyMessage = styled.div`
   width: fit-content;
   padding: 8px;
   border: 1px solid ${colors.violet}${alphaLevel[2]};
@@ -49,6 +55,7 @@ type ComponentProps = {
   operationData: OperationData
   dirsDict: DirsDict
   worksDict: WorksDict
+  revisionsForWorkId: Record<WorkId, BrowserRevision[] | undefined>
 }
 
 export const DirTab = ({ project, operationData, dirsDict, worksDict }: ComponentProps) => {
@@ -99,7 +106,7 @@ export const DirTab = ({ project, operationData, dirsDict, worksDict }: Componen
       {displayedWorks() ? (
         <Label>Works</Label>
       ) : (
-        <Message>Directly and Works has not been, yet. </Message>
+        <EmptyMessage>Directly and Works has not been , yet.</EmptyMessage>
       )}
     </Container>
   )

--- a/pkg/web/src/pages/browser/[[...paths]]/components/Styles/PartsStyles.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/Styles/PartsStyles.tsx
@@ -4,6 +4,8 @@ import { css } from 'styled-components'
 export type DisplayScrollBarStyleProps = { displayedScroll: boolean }
 
 export const DisplayScrollBarStyle = css<DisplayScrollBarStyleProps>`
+  overflow: overlay;
+
   ::-webkit-scrollbar {
     height: 0;
   }
@@ -11,7 +13,6 @@ export const DisplayScrollBarStyle = css<DisplayScrollBarStyleProps>`
   :hover {
     ::-webkit-scrollbar {
       height: ${(props) => (props.displayedScroll ? `${scrollbarSize}` : `0`)};
-      background-color: ${colors.gray}${alphaLevel[1]};
     }
 
     ::-webkit-scrollbar-thumb {
@@ -23,4 +24,8 @@ export const DisplayScrollBarStyle = css<DisplayScrollBarStyleProps>`
 export const FocusByTabKeyStyle = css`
   border: none;
   outline-color: ${colors.gray}${alphaLevel[5]};
+`
+
+export const FontStyle = css`
+  color: ${colors.black}${alphaLevel[7]};
 `

--- a/pkg/web/src/pages/browser/[[...paths]]/components/Styles/PartsStyles.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/Styles/PartsStyles.tsx
@@ -1,4 +1,4 @@
-import { alphaLevel, colors, scrollbarSize } from '@violet/web/src/utils/constants'
+import { alphaLevel, colors, fontSizes, scrollbarSize } from '@violet/web/src/utils/constants'
 import { css } from 'styled-components'
 
 export type DisplayScrollBarStyleProps = { displayedScroll: boolean }
@@ -27,5 +27,6 @@ export const FocusByTabKeyStyle = css`
 `
 
 export const FontStyle = css`
-  color: ${colors.black}${alphaLevel[7]};
+  font-size: ${fontSizes.small};
+  color: ${colors.black}${alphaLevel[9]};
 `

--- a/pkg/web/src/pages/browser/[[...paths]]/components/Tab/WorkTab.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/components/Tab/WorkTab.tsx
@@ -31,6 +31,7 @@ const TabItem = styled.button`
   gap: 4px;
   align-items: center;
   height: ${tabHeight};
+  white-space: nowrap;
   border-right: 1px solid ${colors.violet}${alphaLevel[2]};
   ${ActiveStyle};
 `

--- a/pkg/web/src/pages/browser/[[...paths]]/index.page.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/index.page.tsx
@@ -90,7 +90,6 @@ const Columns = (props: {
               operationData={props.operationData}
               dirsDict={props.dirsDictForProjectId[props.currentProject.id]}
               worksDict={props.worksDictForProjectId[props.currentProject.id]}
-              revisionsForWorkId={props.wholeDict.revisionsForWorkId}
             />
           )}
         </DndProvider>

--- a/pkg/web/src/pages/browser/[[...paths]]/index.page.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/index.page.tsx
@@ -95,6 +95,7 @@ const Columns = (props: {
             operationData={props.operationData}
             dirsDict={props.dirsDictForProjectId[props.currentProject.id]}
             worksDict={props.worksDictForProjectId[props.currentProject.id]}
+            revisionsForWorkId={props.wholeDict.revisionsForWorkId}
           />
         )}
       </WorksView>

--- a/pkg/web/src/pages/browser/[[...paths]]/index.page.tsx
+++ b/pkg/web/src/pages/browser/[[...paths]]/index.page.tsx
@@ -17,6 +17,7 @@ import { EmptyWork } from './components/EmptyWork'
 import { Explorer } from './components/Explorer'
 import { LeftColumn } from './components/LeftColumn'
 import { MainColumn } from './components/MainColumn'
+import { DirTab } from './components/MainColumn/DirTab'
 import { ProjectBar } from './components/ProjectBar'
 import { TabBar } from './components/Tab/TabBar'
 import { usePage } from './usePage'
@@ -89,7 +90,12 @@ const Columns = (props: {
             />
           )
         ) : (
-          <div>Choose work</div>
+          <DirTab
+            project={props.currentProject}
+            operationData={props.operationData}
+            dirsDict={props.dirsDictForProjectId[props.currentProject.id]}
+            worksDict={props.worksDictForProjectId[props.currentProject.id]}
+          />
         )}
       </WorksView>
     </>

--- a/pkg/web/src/utils/index.ts
+++ b/pkg/web/src/utils/index.ts
@@ -1,3 +1,4 @@
+import type { DirId, WorkId } from '@violet/lib/types/branded'
 import { pagesPath } from '@violet/web/src/utils/$path'
 import type {
   BrowserDir,
@@ -39,5 +40,18 @@ export const tabToHref = (
             tab.type === 'work' ? worksDict[tab.id] : undefined
           )
         : [project.name]
+    )
+    .$url()
+
+export const createPath = (
+  dirId: DirId,
+  workId: WorkId | undefined,
+  project: BrowserProject,
+  dirsDict: DirsDict,
+  worksDict: WorksDict
+) =>
+  pagesPath.browser
+    ._paths(
+      getPathNames(project, dirsDict, dirsDict[dirId], workId ? worksDict[workId] : undefined)
     )
     .$url()


### PR DESCRIPTION
## Overview
- Resolves　#157 
- Dirタブ選択時に、Directory と Work のリンクを表示
- Revision の情報を表示させようとしていましたが、
    usePage で新しいリストを作った方がやりやすそうなので、一旦、PRを作成しました

## Image
- WorkId を表示させている部分にWorkのサムネイルを表示させる予定です
![image](https://user-images.githubusercontent.com/52160187/153594744-7262ede4-a962-4632-8abc-ab09a8f5a6d6.png)

